### PR TITLE
feat: 착용 기록 조회 화면 및 기능 구현

### DIFF
--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -76,6 +76,15 @@ export default function HistoryScreen() {
           {item.style} · {item.mood} · {item.tpo}
         </Text>
         <Text style={styles.memo}>{item.memo}</Text>
+
+        <View style={styles.actionRow}>
+          <View style={styles.actionButton}>
+            <Text style={styles.actionButtonText}>상세보기</Text>
+          </View>
+          <View style={styles.actionButton}>
+            <Text style={styles.actionButtonText}>삭제</Text>
+          </View>
+        </View>
       </View>
     );
   };
@@ -198,6 +207,25 @@ const styles = StyleSheet.create({
   memo: {
     fontSize: 14,
     color: '#666',
+  },
+  actionRow: {
+    flexDirection: 'row',
+    justifyContent: 'flex-end',
+    gap: 8,
+    marginTop: 12,
+  },
+  actionButton: {
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  actionButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#333',
   },
   emptyContainer: {
     flex: 1,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import {
+  Alert,
   FlatList,
   Pressable,
   SafeAreaView,
@@ -32,7 +33,7 @@ const clothesData: ClothingItem[] = [
   { id: 'c4', name: '네이비 자켓', category: '아우터', color: '네이비' },
 ];
 
-const historyData: WearHistoryItem[] = [
+const initialHistoryData: WearHistoryItem[] = [
   {
     id: '1',
     date: '2026-04-13',
@@ -75,6 +76,7 @@ const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여�
 
 export default function HistoryScreen() {
   const [selectedFilter, setSelectedFilter] = useState('전체');
+  const [historyList, setHistoryList] = useState<WearHistoryItem[]>(initialHistoryData);
 
   const getClothesByIds = (ids: string[]) => {
     return ids
@@ -84,11 +86,24 @@ export default function HistoryScreen() {
 
   const filteredHistoryData = useMemo(() => {
     if (selectedFilter === '전체') {
-      return historyData;
+      return historyList;
     }
 
-    return historyData.filter((item) => item.tpo === selectedFilter);
-  }, [selectedFilter]);
+    return historyList.filter((item) => item.tpo === selectedFilter);
+  }, [historyList, selectedFilter]);
+
+  const handleDelete = (id: string) => {
+    Alert.alert('기록 삭제', '이 착용 기록을 삭제할까요?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        style: 'destructive',
+        onPress: () => {
+          setHistoryList((prev) => prev.filter((item) => item.id !== id));
+        },
+      },
+    ]);
+  };
 
   const renderItem = ({ item }: { item: WearHistoryItem }) => {
     const clothes = getClothesByIds(item.clothesIds);
@@ -114,12 +129,18 @@ export default function HistoryScreen() {
         <Text style={styles.memo}>{item.memo}</Text>
 
         <View style={styles.actionRow}>
-          <View style={styles.actionButton}>
+          <Pressable style={styles.actionButton}>
             <Text style={styles.actionButtonText}>상세보기</Text>
-          </View>
-          <View style={styles.actionButton}>
-            <Text style={styles.actionButtonText}>삭제</Text>
-          </View>
+          </Pressable>
+
+          <Pressable
+            style={[styles.actionButton, styles.deleteButton]}
+            onPress={() => handleDelete(item.id)}
+          >
+            <Text style={[styles.actionButtonText, styles.deleteButtonText]}>
+              삭제
+            </Text>
+          </Pressable>
         </View>
       </View>
     );
@@ -289,6 +310,12 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: '600',
     color: '#333',
+  },
+  deleteButton: {
+    borderColor: '#f0caca',
+  },
+  deleteButtonText: {
+    color: '#c0392b',
   },
   emptyContainer: {
     flex: 1,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -25,8 +25,27 @@ const clothesData: ClothingItem[] = [
 ];
 
 const historyData: WearHistoryItem[] = [
-  
+  {
+    id: '1',
+    date: '2026-04-13',
+    clothesIds: ['c1', 'c2', 'c3'],
+    style: '미니멀',
+    mood: '차분한',
+    tpo: '데일리',
+    memo: '발표 있어서 단정하게 입음',
+  },
+  {
+    id: '2',
+    date: '2026-04-12',
+    clothesIds: ['c4', 'c1', 'c2'],
+    style: '세미캐주얼',
+    mood: '세련된',
+    tpo: '모임',
+    memo: '저녁 약속',
+  },
 ];
+
+const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여행', '운동'];
 
 export default function HistoryScreen() {
   const getClothesByIds = (ids: string[]) => {
@@ -74,6 +93,14 @@ export default function HistoryScreen() {
         <Text style={styles.title}>착용 기록</Text>
       </View>
 
+      <View style={styles.filterRow}>
+        {filterOptions.map((filter) => (
+          <View key={filter} style={styles.filterChip}>
+            <Text style={styles.filterChipText}>{filter}</Text>
+          </View>
+        ))}
+      </View>
+
       <FlatList
         data={historyData}
         keyExtractor={(item) => item.id}
@@ -102,6 +129,23 @@ const styles = StyleSheet.create({
     fontSize: 28,
     fontWeight: '700',
     color: '#111',
+  },
+  filterRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    marginBottom: 16,
+  },
+  filterChip: {
+    backgroundColor: '#f1f1f1',
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+  },
+  filterChipText: {
+    fontSize: 13,
+    color: '#333',
+    fontWeight: '500',
   },
   listContent: {
     paddingBottom: 24,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,9 +1,41 @@
-import { Text, View } from 'react-native';
+import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
 export default function HistoryScreen() {
   return (
-    <View>
-      <Text>착용 기록 화면</Text>
-    </View>
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>착용 기록</Text>
+      </View>
+
+      <View style={styles.content}>
+        <Text style={styles.placeholder}>착용 기록 화면 준비 중</Text>
+      </View>
+    </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    paddingHorizontal: 16,
+    paddingTop: 16,
+  },
+  header: {
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#111',
+  },
+  content: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  placeholder: {
+    fontSize: 16,
+    color: '#666',
+  },
+});

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,15 +1,56 @@
-import { SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+
+type WearHistoryItem = {
+  id: string;
+  date: string;
+  style?: string;
+  mood?: string;
+  tpo?: string;
+  memo?: string;
+};
+
+const historyData: WearHistoryItem[] = [
+  {
+    id: '1',
+    date: '2026-04-13',
+    style: '미니멀',
+    mood: '차분한',
+    tpo: '데일리',
+    memo: '발표 있어서 단정하게 입음',
+  },
+  {
+    id: '2',
+    date: '2026-04-12',
+    style: '캐주얼',
+    mood: '활동적인',
+    tpo: '여행',
+    memo: '가볍게 외출',
+  },
+];
 
 export default function HistoryScreen() {
+  const renderItem = ({ item }: { item: WearHistoryItem }) => (
+    <View style={styles.card}>
+      <Text style={styles.date}>{item.date}</Text>
+      <Text style={styles.tags}>
+        {item.style} · {item.mood} · {item.tpo}
+      </Text>
+      <Text style={styles.memo}>{item.memo}</Text>
+    </View>
+  );
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>착용 기록</Text>
       </View>
 
-      <View style={styles.content}>
-        <Text style={styles.placeholder}>착용 기록 화면 준비 중</Text>
-      </View>
+      <FlatList
+        data={historyData}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+        contentContainerStyle={styles.listContent}
+      />
     </SafeAreaView>
   );
 }
@@ -22,20 +63,35 @@ const styles = StyleSheet.create({
     paddingTop: 16,
   },
   header: {
-    marginBottom: 20,
+    marginBottom: 12,
   },
   title: {
     fontSize: 28,
     fontWeight: '700',
     color: '#111',
   },
-  content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
+  listContent: {
+    paddingBottom: 24,
   },
-  placeholder: {
+  card: {
+    backgroundColor: '#f7f7f7',
+    borderRadius: 14,
+    padding: 16,
+    marginBottom: 12,
+  },
+  date: {
     fontSize: 16,
+    fontWeight: '700',
+    color: '#111',
+    marginBottom: 8,
+  },
+  tags: {
+    fontSize: 14,
+    color: '#444',
+    marginBottom: 6,
+  },
+  memo: {
+    fontSize: 14,
     color: '#666',
   },
 });

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,4 +1,12 @@
-import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
+import { useState } from 'react';
+import {
+  FlatList,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
 
 type ClothingItem = {
   id: string;
@@ -48,6 +56,8 @@ const historyData: WearHistoryItem[] = [
 const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여행', '운동'];
 
 export default function HistoryScreen() {
+  const [selectedFilter, setSelectedFilter] = useState('전체');
+
   const getClothesByIds = (ids: string[]) => {
     return ids
       .map((id) => clothesData.find((cloth) => cloth.id === id))
@@ -103,11 +113,29 @@ export default function HistoryScreen() {
       </View>
 
       <View style={styles.filterRow}>
-        {filterOptions.map((filter) => (
-          <View key={filter} style={styles.filterChip}>
-            <Text style={styles.filterChipText}>{filter}</Text>
-          </View>
-        ))}
+        {filterOptions.map((filter) => {
+          const isSelected = selectedFilter === filter;
+
+          return (
+            <Pressable
+              key={filter}
+              style={[
+                styles.filterChip,
+                isSelected && styles.filterChipSelected,
+              ]}
+              onPress={() => setSelectedFilter(filter)}
+            >
+              <Text
+                style={[
+                  styles.filterChipText,
+                  isSelected && styles.filterChipTextSelected,
+                ]}
+              >
+                {filter}
+              </Text>
+            </Pressable>
+          );
+        })}
       </View>
 
       <FlatList
@@ -119,6 +147,7 @@ export default function HistoryScreen() {
           historyData.length === 0 && styles.emptyListContent,
         ]}
         ListEmptyComponent={<EmptyState />}
+        showsVerticalScrollIndicator={false}
       />
     </SafeAreaView>
   );
@@ -151,10 +180,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingVertical: 8,
   },
+  filterChipSelected: {
+    backgroundColor: '#111',
+  },
   filterChipText: {
     fontSize: 13,
     color: '#333',
     fontWeight: '500',
+  },
+  filterChipTextSelected: {
+    color: '#fff',
   },
   listContent: {
     paddingBottom: 24,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   FlatList,
   Pressable,
@@ -51,9 +51,27 @@ const historyData: WearHistoryItem[] = [
     tpo: '모임',
     memo: '저녁 약속',
   },
+  {
+    id: '3',
+    date: '2026-04-10',
+    clothesIds: ['c1', 'c3'],
+    style: '캐주얼',
+    mood: '활동적인',
+    tpo: '여행',
+    memo: '가볍게 외출',
+  },
+  {
+    id: '4',
+    date: '2026-04-08',
+    clothesIds: ['c2', 'c3'],
+    style: '스포티',
+    mood: '활동적인',
+    tpo: '운동',
+    memo: '편하게 입음',
+  },
 ];
 
-const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여행', '운동'];
+const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여행', '운동', '모임'];
 
 export default function HistoryScreen() {
   const [selectedFilter, setSelectedFilter] = useState('전체');
@@ -63,6 +81,14 @@ export default function HistoryScreen() {
       .map((id) => clothesData.find((cloth) => cloth.id === id))
       .filter(Boolean) as ClothingItem[];
   };
+
+  const filteredHistoryData = useMemo(() => {
+    if (selectedFilter === '전체') {
+      return historyData;
+    }
+
+    return historyData.filter((item) => item.tpo === selectedFilter);
+  }, [selectedFilter]);
 
   const renderItem = ({ item }: { item: WearHistoryItem }) => {
     const clothes = getClothesByIds(item.clothesIds);
@@ -101,8 +127,10 @@ export default function HistoryScreen() {
 
   const EmptyState = () => (
     <View style={styles.emptyContainer}>
-      <Text style={styles.emptyTitle}>아직 착용 기록이 없습니다</Text>
-      <Text style={styles.emptyDescription}>오늘 입은 옷을 기록해보세요.</Text>
+      <Text style={styles.emptyTitle}>해당 조건의 착용 기록이 없습니다</Text>
+      <Text style={styles.emptyDescription}>
+        다른 필터를 선택하거나 새 기록을 추가해보세요.
+      </Text>
     </View>
   );
 
@@ -139,12 +167,12 @@ export default function HistoryScreen() {
       </View>
 
       <FlatList
-        data={historyData}
+        data={filteredHistoryData}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
         contentContainerStyle={[
           styles.listContent,
-          historyData.length === 0 && styles.emptyListContent,
+          filteredHistoryData.length === 0 && styles.emptyListContent,
         ]}
         ListEmptyComponent={<EmptyState />}
         showsVerticalScrollIndicator={false}
@@ -272,9 +300,11 @@ const styles = StyleSheet.create({
     fontWeight: '700',
     color: '#222',
     marginBottom: 8,
+    textAlign: 'center',
   },
   emptyDescription: {
     fontSize: 14,
     color: '#777',
+    textAlign: 'center',
   },
 });

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -73,7 +73,18 @@ const initialHistoryData: WearHistoryItem[] = [
   },
 ];
 
-const filterOptions = ['전체', '데일리', '비즈니스', '데이트', '여행', '운동', '모임'];
+const filterOptions = [
+  '전체',
+  '데일리',
+  '비즈니스',
+  '면접',
+  '결혼식',
+  '장례식',
+  '운동',
+  '데이트',
+  '모임',
+  '여행',
+];
 
 export default function HistoryScreen() {
   const [selectedFilter, setSelectedFilter] = useState('전체');
@@ -121,6 +132,10 @@ export default function HistoryScreen() {
         clothes: JSON.stringify(clothes),
       },
     });
+  };
+
+  const handleCreatePress = () => {
+    router.push('/history-create');
   };
 
   const renderItem = ({ item }: { item: WearHistoryItem }) => {
@@ -178,8 +193,12 @@ export default function HistoryScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.header}>
+      <View style={styles.headerRow}>
         <Text style={styles.title}>착용 기록</Text>
+
+        <Pressable style={styles.addButton} onPress={handleCreatePress}>
+          <Text style={styles.addButtonText}>+ 추가</Text>
+        </Pressable>
       </View>
 
       <View style={styles.filterRow}>
@@ -230,13 +249,27 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingTop: 16,
   },
-  header: {
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
     marginBottom: 12,
   },
   title: {
     fontSize: 28,
     fontWeight: '700',
     color: '#111',
+  },
+  addButton: {
+    backgroundColor: '#111',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+  },
+  addButtonText: {
+    color: '#fff',
+    fontSize: 13,
+    fontWeight: '600',
   },
   filterRow: {
     flexDirection: 'row',

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,18 +1,34 @@
 import { FlatList, SafeAreaView, StyleSheet, Text, View } from 'react-native';
 
+type ClothingItem = {
+  id: string;
+  name: string;
+  category: string;
+  color: string;
+};
+
 type WearHistoryItem = {
   id: string;
   date: string;
+  clothesIds: string[];
   style?: string;
   mood?: string;
   tpo?: string;
   memo?: string;
 };
 
+const clothesData: ClothingItem[] = [
+  { id: 'c1', name: '블랙 셔츠', category: '상의', color: '블랙' },
+  { id: 'c2', name: '베이지 슬랙스', category: '하의', color: '베이지' },
+  { id: 'c3', name: '화이트 스니커즈', category: '신발', color: '화이트' },
+  { id: 'c4', name: '네이비 자켓', category: '아우터', color: '네이비' },
+];
+
 const historyData: WearHistoryItem[] = [
   {
     id: '1',
     date: '2026-04-13',
+    clothesIds: ['c1', 'c2', 'c3'],
     style: '미니멀',
     mood: '차분한',
     tpo: '데일리',
@@ -21,23 +37,46 @@ const historyData: WearHistoryItem[] = [
   {
     id: '2',
     date: '2026-04-12',
-    style: '캐주얼',
-    mood: '활동적인',
-    tpo: '여행',
-    memo: '가볍게 외출',
+    clothesIds: ['c4', 'c1', 'c2'],
+    style: '세미캐주얼',
+    mood: '세련된',
+    tpo: '모임',
+    memo: '저녁 약속',
   },
 ];
 
 export default function HistoryScreen() {
-  const renderItem = ({ item }: { item: WearHistoryItem }) => (
-    <View style={styles.card}>
-      <Text style={styles.date}>{item.date}</Text>
-      <Text style={styles.tags}>
-        {item.style} · {item.mood} · {item.tpo}
-      </Text>
-      <Text style={styles.memo}>{item.memo}</Text>
-    </View>
-  );
+  const getClothesByIds = (ids: string[]) => {
+    return ids
+      .map((id) => clothesData.find((cloth) => cloth.id === id))
+      .filter(Boolean) as ClothingItem[];
+  };
+
+  const renderItem = ({ item }: { item: WearHistoryItem }) => {
+    const clothes = getClothesByIds(item.clothesIds);
+
+    return (
+      <View style={styles.card}>
+        <Text style={styles.date}>{item.date}</Text>
+
+        <View style={styles.clothesRow}>
+          {clothes.map((cloth) => (
+            <View key={cloth.id} style={styles.clothBox}>
+              <Text style={styles.clothCategory}>{cloth.category}</Text>
+              <Text style={styles.clothName} numberOfLines={1}>
+                {cloth.name}
+              </Text>
+            </View>
+          ))}
+        </View>
+
+        <Text style={styles.tags}>
+          {item.style} · {item.mood} · {item.tpo}
+        </Text>
+        <Text style={styles.memo}>{item.memo}</Text>
+      </View>
+    );
+  };
 
   return (
     <SafeAreaView style={styles.container}>
@@ -83,7 +122,32 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: '700',
     color: '#111',
-    marginBottom: 8,
+    marginBottom: 10,
+  },
+  clothesRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginBottom: 10,
+  },
+  clothBox: {
+    flex: 1,
+    minHeight: 72,
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 8,
+    justifyContent: 'center',
+    borderWidth: 1,
+    borderColor: '#eee',
+  },
+  clothCategory: {
+    fontSize: 12,
+    color: '#888',
+    marginBottom: 4,
+  },
+  clothName: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: '#222',
   },
   tags: {
     fontSize: 14,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,3 +1,4 @@
+import { router } from 'expo-router';
 import { useMemo, useState } from 'react';
 import {
   Alert,
@@ -105,6 +106,23 @@ export default function HistoryScreen() {
     ]);
   };
 
+  const handleDetailPress = (item: WearHistoryItem) => {
+    const clothes = getClothesByIds(item.clothesIds);
+
+    router.push({
+      pathname: '/history-detail',
+      params: {
+        id: item.id,
+        date: item.date,
+        style: item.style ?? '',
+        mood: item.mood ?? '',
+        tpo: item.tpo ?? '',
+        memo: item.memo ?? '',
+        clothes: JSON.stringify(clothes),
+      },
+    });
+  };
+
   const renderItem = ({ item }: { item: WearHistoryItem }) => {
     const clothes = getClothesByIds(item.clothesIds);
 
@@ -129,7 +147,10 @@ export default function HistoryScreen() {
         <Text style={styles.memo}>{item.memo}</Text>
 
         <View style={styles.actionRow}>
-          <Pressable style={styles.actionButton}>
+          <Pressable
+            style={styles.actionButton}
+            onPress={() => handleDetailPress(item)}
+          >
             <Text style={styles.actionButtonText}>상세보기</Text>
           </Pressable>
 

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -25,24 +25,7 @@ const clothesData: ClothingItem[] = [
 ];
 
 const historyData: WearHistoryItem[] = [
-  {
-    id: '1',
-    date: '2026-04-13',
-    clothesIds: ['c1', 'c2', 'c3'],
-    style: '미니멀',
-    mood: '차분한',
-    tpo: '데일리',
-    memo: '발표 있어서 단정하게 입음',
-  },
-  {
-    id: '2',
-    date: '2026-04-12',
-    clothesIds: ['c4', 'c1', 'c2'],
-    style: '세미캐주얼',
-    mood: '세련된',
-    tpo: '모임',
-    memo: '저녁 약속',
-  },
+  
 ];
 
 export default function HistoryScreen() {
@@ -78,6 +61,13 @@ export default function HistoryScreen() {
     );
   };
 
+  const EmptyState = () => (
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>아직 착용 기록이 없습니다</Text>
+      <Text style={styles.emptyDescription}>오늘 입은 옷을 기록해보세요.</Text>
+    </View>
+  );
+
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
@@ -88,7 +78,11 @@ export default function HistoryScreen() {
         data={historyData}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
-        contentContainerStyle={styles.listContent}
+        contentContainerStyle={[
+          styles.listContent,
+          historyData.length === 0 && styles.emptyListContent,
+        ]}
+        ListEmptyComponent={<EmptyState />}
       />
     </SafeAreaView>
   );
@@ -111,6 +105,9 @@ const styles = StyleSheet.create({
   },
   listContent: {
     paddingBottom: 24,
+  },
+  emptyListContent: {
+    flexGrow: 1,
   },
   card: {
     backgroundColor: '#f7f7f7',
@@ -157,5 +154,20 @@ const styles = StyleSheet.create({
   memo: {
     fontSize: 14,
     color: '#666',
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#222',
+    marginBottom: 8,
+  },
+  emptyDescription: {
+    fontSize: 14,
+    color: '#777',
   },
 });

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -1,0 +1,315 @@
+import { Stack, router } from 'expo-router';
+import { useMemo, useState } from 'react';
+import {
+    Alert,
+    Pressable,
+    SafeAreaView,
+    ScrollView,
+    StyleSheet,
+    Text,
+    TextInput,
+    View,
+} from 'react-native';
+
+type ClothingItem = {
+  id: string;
+  name: string;
+  category: string;
+  color: string;
+};
+
+// 👉 임시 옷 데이터 (나중에 API로 교체)
+const clothesData: ClothingItem[] = [
+  { id: 'c1', name: '블랙 셔츠', category: '상의', color: '블랙' },
+  { id: 'c2', name: '베이지 슬랙스', category: '하의', color: '베이지' },
+  { id: 'c3', name: '화이트 스니커즈', category: '신발', color: '화이트' },
+  { id: 'c4', name: '네이비 자켓', category: '아우터', color: '네이비' },
+];
+
+// 👉 TPO (수정된 최종 버전)
+const tpoOptions = [
+  '데일리',
+  '비즈니스',
+  '면접',
+  '결혼식',
+  '장례식',
+  '운동',
+  '데이트',
+  '모임',
+  '여행',
+];
+
+const fitOptions = ['슬림', '레귤러', '오버핏'];
+const temperatureOptions = ['추움', '적당함', '더움'];
+
+export default function HistoryCreateScreen() {
+  const today = new Date().toISOString().slice(0, 10);
+
+  const [selectedClothes, setSelectedClothes] = useState<string[]>([]);
+  const [tpo, setTpo] = useState('');
+  const [fit, setFit] = useState('');
+  const [temperature, setTemperature] = useState('');
+  const [memo, setMemo] = useState('');
+
+  // 👉 카테고리별로 묶기
+  const groupedClothes = useMemo(() => {
+    return {
+      상의: clothesData.filter((item) => item.category === '상의'),
+      하의: clothesData.filter((item) => item.category === '하의'),
+      아우터: clothesData.filter((item) => item.category === '아우터'),
+      신발: clothesData.filter((item) => item.category === '신발'),
+    };
+  }, []);
+
+  // 👉 옷 선택 토글
+  const toggleCloth = (id: string) => {
+    setSelectedClothes((prev) =>
+      prev.includes(id)
+        ? prev.filter((item) => item !== id)
+        : [...prev, id]
+    );
+  };
+
+  // 👉 공통 칩 UI
+  const renderChips = (
+    options: string[],
+    selected: string,
+    setValue: (value: string) => void
+  ) => {
+    return (
+      <View style={styles.chipRow}>
+        {options.map((option) => {
+          const isSelected = selected === option;
+
+          return (
+            <Pressable
+              key={option}
+              style={[styles.chip, isSelected && styles.chipSelected]}
+              onPress={() => setValue(option)}
+            >
+              <Text
+                style={[
+                  styles.chipText,
+                  isSelected && styles.chipTextSelected,
+                ]}
+              >
+                {option}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
+    );
+  };
+
+  // 👉 저장
+  const handleSave = () => {
+    if (selectedClothes.length === 0) {
+      Alert.alert('안내', '옷을 선택해주세요.');
+      return;
+    }
+
+    if (!tpo) {
+      Alert.alert('안내', 'TPO를 선택해주세요.');
+      return;
+    }
+
+    const payload = {
+      date: today,
+      clothesIds: selectedClothes,
+      tpo,
+      fit,
+      temperature,
+      memo,
+    };
+
+    console.log('저장 데이터:', payload);
+
+    Alert.alert('저장 완료', '착용 기록이 저장되었습니다.', [
+      {
+        text: '확인',
+        onPress: () => router.back(),
+      },
+    ]);
+  };
+
+  return (
+    <>
+      <Stack.Screen options={{ title: '착용 기록 추가' }} />
+
+      <SafeAreaView style={styles.container}>
+        <ScrollView contentContainerStyle={styles.content}>
+          
+          {/* 날짜 */}
+          <View style={styles.section}>
+            <Text style={styles.title}>날짜</Text>
+            <Text style={styles.value}>{today}</Text>
+          </View>
+
+          {/* 옷 선택 */}
+          <View style={styles.section}>
+            <Text style={styles.title}>오늘 입은 옷</Text>
+
+            {Object.entries(groupedClothes).map(([category, items]) => (
+              <View key={category} style={{ marginTop: 10 }}>
+                <Text style={styles.subTitle}>{category}</Text>
+
+                <View style={styles.clothRow}>
+                  {items.map((item) => {
+                    const isSelected = selectedClothes.includes(item.id);
+
+                    return (
+                      <Pressable
+                        key={item.id}
+                        style={[
+                          styles.clothBox,
+                          isSelected && styles.clothBoxSelected,
+                        ]}
+                        onPress={() => toggleCloth(item.id)}
+                      >
+                        <Text style={styles.clothName}>{item.name}</Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+              </View>
+            ))}
+          </View>
+
+          {/* TPO */}
+          <View style={styles.section}>
+            <Text style={styles.title}>TPO</Text>
+            {renderChips(tpoOptions, tpo, setTpo)}
+          </View>
+
+          {/* 핏 */}
+          <View style={styles.section}>
+            <Text style={styles.title}>핏</Text>
+            {renderChips(fitOptions, fit, setFit)}
+          </View>
+
+          {/* 체감온도 */}
+          <View style={styles.section}>
+            <Text style={styles.title}>체감온도</Text>
+            {renderChips(temperatureOptions, temperature, setTemperature)}
+          </View>
+
+          {/* 메모 */}
+          <View style={styles.section}>
+            <Text style={styles.title}>메모</Text>
+            <TextInput
+              style={styles.input}
+              placeholder="오늘 착장에 대한 메모를 입력하세요"
+              value={memo}
+              onChangeText={setMemo}
+              multiline
+            />
+          </View>
+
+          {/* 저장 버튼 */}
+          <Pressable style={styles.saveButton} onPress={handleSave}>
+            <Text style={styles.saveText}>저장하기</Text>
+          </Pressable>
+
+        </ScrollView>
+      </SafeAreaView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, backgroundColor: '#fff' },
+  content: { padding: 16, paddingBottom: 40 },
+
+  section: {
+    marginBottom: 20,
+  },
+
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    marginBottom: 8,
+  },
+
+  subTitle: {
+    fontSize: 13,
+    color: '#666',
+    marginBottom: 6,
+  },
+
+  value: {
+    fontSize: 15,
+    color: '#111',
+  },
+
+  clothRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+
+  clothBox: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    backgroundColor: '#f1f1f1',
+  },
+
+  clothBoxSelected: {
+    backgroundColor: '#111',
+  },
+
+  clothName: {
+    color: '#333',
+    fontSize: 13,
+  },
+
+  chipRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+
+  chip: {
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 999,
+    backgroundColor: '#f1f1f1',
+  },
+
+  chipSelected: {
+    backgroundColor: '#111',
+  },
+
+  chipText: {
+    fontSize: 13,
+    color: '#333',
+  },
+
+  chipTextSelected: {
+    color: '#fff',
+  },
+
+  input: {
+    borderWidth: 1,
+    borderColor: '#ddd',
+    borderRadius: 10,
+    padding: 12,
+    minHeight: 80,
+    textAlignVertical: 'top',
+  },
+
+  saveButton: {
+    marginTop: 10,
+    backgroundColor: '#111',
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: 'center',
+  },
+
+  saveText: {
+    color: '#fff',
+    fontSize: 16,
+    fontWeight: '700',
+  },
+});

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -1,0 +1,123 @@
+import { Stack, useLocalSearchParams } from 'expo-router';
+import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+
+type ClothingItem = {
+  id: string;
+  name: string;
+  category: string;
+  color: string;
+};
+
+export default function HistoryDetailScreen() {
+  const params = useLocalSearchParams<{
+    id?: string;
+    date?: string;
+    style?: string;
+    mood?: string;
+    tpo?: string;
+    memo?: string;
+    clothes?: string;
+  }>();
+
+  const clothes: ClothingItem[] = params.clothes
+    ? JSON.parse(params.clothes)
+    : [];
+
+  return (
+    <>
+      <Stack.Screen options={{ title: '착용 기록 상세' }} />
+
+      <SafeAreaView style={styles.container}>
+        <ScrollView contentContainerStyle={styles.content}>
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>날짜</Text>
+            <Text style={styles.sectionValue}>{params.date || '-'}</Text>
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>피드백 태그</Text>
+            <Text style={styles.sectionValue}>
+              {params.style || '-'} · {params.mood || '-'} · {params.tpo || '-'}
+            </Text>
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>메모</Text>
+            <Text style={styles.sectionValue}>{params.memo || '메모 없음'}</Text>
+          </View>
+
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>착용한 옷</Text>
+
+            {clothes.length > 0 ? (
+              clothes.map((cloth) => (
+                <View key={cloth.id} style={styles.clothCard}>
+                  <Text style={styles.clothCategory}>{cloth.category}</Text>
+                  <Text style={styles.clothName}>{cloth.name}</Text>
+                  <Text style={styles.clothColor}>색상: {cloth.color}</Text>
+                </View>
+              ))
+            ) : (
+              <Text style={styles.emptyText}>표시할 옷 정보가 없습니다.</Text>
+            )}
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+  },
+  content: {
+    padding: 16,
+    paddingBottom: 24,
+  },
+  section: {
+    backgroundColor: '#f7f7f7',
+    borderRadius: 14,
+    padding: 16,
+    marginBottom: 12,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#555',
+    marginBottom: 8,
+  },
+  sectionValue: {
+    fontSize: 16,
+    color: '#111',
+    lineHeight: 22,
+  },
+  clothCard: {
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 12,
+    marginTop: 8,
+    borderWidth: 1,
+    borderColor: '#ececec',
+  },
+  clothCategory: {
+    fontSize: 12,
+    color: '#888',
+    marginBottom: 4,
+  },
+  clothName: {
+    fontSize: 15,
+    fontWeight: '600',
+    color: '#222',
+    marginBottom: 4,
+  },
+  clothColor: {
+    fontSize: 13,
+    color: '#666',
+  },
+  emptyText: {
+    fontSize: 14,
+    color: '#777',
+  },
+});


### PR DESCRIPTION
## 개요
착용 기록 조회 화면(history), 상세 화면(history-detail), 입력 화면(history-create)을 구현하고,
history 관련 API 연동을 진행함.

## 구현 내용

### 조회 화면 (history)
- 착용 기록 리스트 UI 구현
- 착용 아이템 미리보기 카드 UI 구현
- TPO 필터 UI 및 선택 상태 구현
- TPO 기준 필터링 기능 구현
- 상세보기 버튼 클릭 시 상세 페이지 이동 구현
- 화면 상단에 기록 추가 버튼 구현

### 상세 화면 (history-detail)
- 착용 기록 상세 페이지 UI 구현

### 입력 화면 (history-create)
- 착용 기록 입력 화면 추가
- 날짜 표시 UI 구현
- 오늘 입은 옷 선택 UI 구현
- TPO / 핏 / 체감온도 / 메모 입력 UI 구현
- 저장 버튼 및 기본 예외 처리(Alert) 구현
- 기록 추가 버튼 클릭 시 history-create 화면으로 이동 구현

---

## API 연동 진행 내용
- GET /history 연동 → 착용 기록 조회
- DELETE /history/{id} 연동 → 착용 기록 삭제
- GET /clothes 연동 시도
- POST /history 연동 시도
- POST /history 요청을 list 형태로 맞춰 테스트 진행

---

## 현재 상태 및 이슈

- GET /clothes 응답이 비어 있어 실제 clothes_id 기반 테스트가 어려움
- 이를 위해 mock 데이터 fallback 처리
- mock 데이터 사용 중에는 실제 저장이 되지 않도록 저장 제한 적용
- POST /history 요청 body 형식 및 필수 필드(clothes_id, worn_date 등) 확인 필요
- 실제 DB에 존재하는 clothes_id 기준으로 history 저장이 정상 동작하는지 백엔드 확인 필요

---

## 변경 파일
- history.tsx: 조회 화면 UI 및 API 연동
- history-detail.tsx: 상세 페이지 UI 추가
- history-create.tsx: 입력 화면 추가 및 API 연동 시도

---

## 관련 이슈
- Refs #38
- Refs #9
- Related to #52
- Related to #53