### PR TITLE
feat: 옷장 통계, 가성비 산출 및 처분 분석 API 구현 완료 (#3, #4, #5)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
+from routers import stats, history
 
 load_dotenv()  # .env 파일 자동 로드
 
@@ -32,10 +33,10 @@ app.include_router(recommend.router)
 app.include_router(weather.router)
 app.include_router(vision.router)
 
+
 # C 담당자가 추가할 라우터
-from routers import history
 app.include_router(history.router)
-# app.include_router(stats.router)
+app.include_router(stats.router)
 
 @app.get("/")
 def root():

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -42,3 +42,27 @@ def get_top_frequency(db: Session = Depends(get_db)):
     ).order_by(Clothes.wear_count.desc()).limit(5).all()
     
     return {"message": "가장 즐겨 입는 상위 5벌 조회", "data": top_clothes}
+
+
+@router.get("/disposal-recommendation")
+def get_disposal_recommendation(db: Session = Depends(get_db)):
+    current_user_id = 1
+    ninety_days_ago = datetime.now() - timedelta(days=90)
+    
+    disposal_targets = (
+        db.query(Clothes)
+        .filter(
+            Clothes.user_id == current_user_id,
+            (Clothes.last_worn_date <= ninety_days_ago) |
+            (
+                ((Clothes.wear_count == 0) | (Clothes.wear_count == None)) & 
+                (Clothes.created_at <= ninety_days_ago)
+            )
+        )
+        .all()
+    )
+    
+    return {
+        "message": f"90일 이상 방치된 옷이 {len(disposal_targets)}벌 있습니다. 처분을 고려해 보세요.", 
+        "data": disposal_targets
+    }

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -81,13 +81,15 @@ def get_cost_efficiency(db: Session = Depends(get_db)):
 
     sorted_clothes = sorted(clothes, key=lambda x: x.cost_per_wear)
 
+    worst_items = sorted_clothes[-3:] if len(sorted_clothes) > 3 else []
+
     return {
         "message": "가성비 분석 완료",
-        "best_efficiency": sorted_clothes[:3],   # UI용 가성비 좋은 옷
-        "worst_efficiency": sorted_clothes[-3:], # UI용 가성비 나쁜 옷
-        "ai_summary": {                          # AI 프롬프트용 요약 데이터
+        "best_efficiency": sorted_clothes[:3], 
+        "worst_efficiency": worst_items, 
+        "ai_summary": { 
             "most_efficient_item": sorted_clothes[0].name if sorted_clothes else None,
-            "total_investment_on_worst": sum(c.purchase_price for c in sorted_clothes[-3:])
+            "total_investment_on_worst": sum(c.purchase_price for c in worst_items)
         }
     }
 

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -90,3 +90,24 @@ def get_cost_efficiency(db: Session = Depends(get_db)):
             "total_investment_on_worst": sum(c.purchase_price for c in sorted_clothes[-3:])
         }
     }
+
+
+# 옷장 과부하 분석 API
+@router.get("/overload-analysis")
+def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
+    current_user_id = 1
+    
+    # 카테고리/색상별 그룹화 및 threshold 이상 중복 감지
+    overloaded_groups = (
+        db.query(
+            Clothes.category, 
+            Clothes.color, 
+            func.count(Clothes.clothes_id).label("count")
+        )
+        .filter(Clothes.user_id == current_user_id)
+        .group_by(Clothes.category, Clothes.color)
+        .having(func.count(Clothes.clothes_id) >= threshold)
+        .all()
+    )
+
+    return {"message": f"중복 보유 카테고리 {len(overloaded_groups)}건 발견"}

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+from typing import List
+from database import get_db
+from models import Clothes
+
+# 통계 API 라우터 설정
+router = APIRouter(prefix="/stats", tags=["통계 및 분석"])
+
+
+# 미착용 옷 분석 API
+@router.get("/unworn")
+def get_unworn_clothes(db: Session = Depends(get_db)):
+    current_user_id = 1  # TODO: 인증 모듈 연동 필요
+    
+    # wear_count가 0이거나 데이터가 없는 옷 필터링
+    unworn_clothes = db.query(Clothes).filter(
+        Clothes.user_id == current_user_id,
+        (Clothes.wear_count == 0) | (Clothes.wear_count == None)
+    ).all()
+    
+    return {"message": f"미착용 옷 {len(unworn_clothes)}벌 조회 성공", "data": unworn_clothes}

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -45,22 +45,22 @@ def get_top_frequency(db: Session = Depends(get_db)):
 @router.get("/disposal-recommendation")
 def get_disposal_recommendation(db: Session = Depends(get_db)):
     current_user_id = 1
-    ninety_days_ago = datetime.now() - timedelta(days=90)
+    
+    # Date와 DateTime 변수 명확히 분리
+    ninety_days_ago_datetime = datetime.now() - timedelta(days=90)
+    ninety_days_ago_date = ninety_days_ago_datetime.date() 
     
     disposal_targets = (
         db.query(Clothes)
         .filter(
             Clothes.user_id == current_user_id,
-            (Clothes.last_worn_date <= ninety_days_ago) |
+            (Clothes.last_worn_date <= ninety_days_ago_date) | 
             (
                 ((Clothes.wear_count == 0) | (Clothes.wear_count == None)) & 
-                (Clothes.created_at <= ninety_days_ago)
+                (Clothes.created_at <= ninety_days_ago_datetime) 
             )
         )
         .all()
     )
     
-    return {
-        "message": f"90일 이상 방치된 옷이 {len(disposal_targets)}벌 있습니다. 처분을 고려해 보세요.", 
-        "data": disposal_targets
-    }
+    return {"message": f"90일 방치 옷 {len(disposal_targets)}벌 조회 완료", "data": disposal_targets}

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -26,7 +26,7 @@ def get_underutilized_clothes(current_season: SeasonEnum, db: Session = Depends(
         .limit(10)
         .all()
     )
-    
+
     return {"message": f"우선 추천 후보 추출 완료", "data": priority_clothes}
 
 # 착용 빈도 통계 API
@@ -124,4 +124,10 @@ def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
             "items": items
         })
 
-    return {"message": f"과다 보유 리포트: {len(detailed_data)}건 발견", "data": detailed_data}
+
+    return {
+        "message": f"과다 보유 리포트: {len(detailed_data)}건 발견",
+        "overload_details": detailed_data,
+        "ai_insight": f"사용자는 현재 {len(detailed_data)}개의 스타일에서 중복 구매 패턴을 보입니다."
+    }
+

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -110,4 +110,18 @@ def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
         .all()
     )
 
-    return {"message": f"중복 보유 카테고리 {len(overloaded_groups)}건 발견"}
+    detailed_data = []
+    for group in overloaded_groups:
+        items = db.query(Clothes).filter(
+            Clothes.user_id == current_user_id,
+            Clothes.category == group.category,
+            Clothes.color == group.color
+        ).all()
+        detailed_data.append({
+            "category": group.category,
+            "color": group.color,
+            "count": group.count,
+            "items": items
+        })
+
+    return {"message": f"과다 보유 리포트: {len(detailed_data)}건 발견", "data": detailed_data}

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
+from datetime import datetime, timedelta 
 from database import get_db
 from models import Clothes
 
@@ -8,18 +9,26 @@ from models import Clothes
 router = APIRouter(prefix="/stats", tags=["통계 및 분석"])
 
 
-# 미착용 옷 분석 API
-@router.get("/unworn")
-def get_unworn_clothes(db: Session = Depends(get_db)):
-    current_user_id = 1  # TODO: 인증 모듈 연동 필요
+# 미착용 옷/ 재활용 옷 우선순위 추출 API
+@router.get("/unworn/priority")
+def get_underutilized_clothes(current_season: str, db: Session = Depends(get_db)):
+    current_user_id = 1 
     
-    # wear_count가 0이거나 데이터가 없는 옷 필터링
-    unworn_clothes = db.query(Clothes).filter(
-        Clothes.user_id == current_user_id,
-        (Clothes.wear_count == 0) | (Clothes.wear_count == None)
-    ).all()
+    priority_clothes = (
+        db.query(Clothes)
+        .filter(
+            Clothes.user_id == current_user_id,
+            Clothes.season == current_season
+        )
+        .order_by(Clothes.wear_count.asc())
+        .limit(10)
+        .all()
+    )
     
-    return {"message": f"미착용 옷 {len(unworn_clothes)}벌 조회 성공", "data": unworn_clothes}
+    return {
+        "message": f"이번 {current_season} 시즌에 우선적으로 활용할 옷을 찾았습니다.", 
+        "data": priority_clothes
+    }
 
 # 착용 빈도 통계 API
 @router.get("/frequency/top")

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -79,4 +79,14 @@ def get_cost_efficiency(db: Session = Depends(get_db)):
         Clothes.wear_count > 0
     ).all()
 
-    return {"message": f"가성비 계산 대상 {len(clothes)}벌 추출 완료"}
+    sorted_clothes = sorted(clothes, key=lambda x: x.cost_per_wear)
+
+    return {
+        "message": "가성비 분석 완료",
+        "best_efficiency": sorted_clothes[:3],   # UI용 가성비 좋은 옷
+        "worst_efficiency": sorted_clothes[-3:], # UI용 가성비 나쁜 옷
+        "ai_summary": {                          # AI 프롬프트용 요약 데이터
+            "most_efficient_item": sorted_clothes[0].name if sorted_clothes else None,
+            "total_investment_on_worst": sum(c.purchase_price for c in sorted_clothes[-3:])
+        }
+    }

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -55,9 +55,12 @@ def get_disposal_recommendation(db: Session = Depends(get_db)):
         db.query(Clothes)
         .filter(
             Clothes.user_id == current_user_id,
+            # 💡 [추가 1] 1. 최근 90일 동안 입지 않은 옷
             (Clothes.last_worn_date <= ninety_days_ago_date) | 
             (
-                ((Clothes.wear_count == 0) | (Clothes.wear_count == None)) & 
+                # 💡 [추가 2] 2. 한 번도 입지 않았고, 등록된 지 90일이 지난 옷
+                # 💡 [수정 3, 4] == None을 SQLAlchemy 권장 방식인 is_(None)으로 교체
+                ((Clothes.wear_count == 0) | Clothes.wear_count.is_(None)) & 
                 (Clothes.created_at <= ninety_days_ago_datetime) 
             )
         )

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,34 +1,32 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
 from typing import List
-from datetime import datetime, timedelta 
+from datetime import datetime, timedelta, date 
 from database import get_db
-from models import Clothes
+from models import Clothes, SeasonEnum
 
-# 통계 API 라우터 설정
+
 router = APIRouter(prefix="/stats", tags=["통계 및 분석"])
 
 
 # 미착용 옷/ 재활용 옷 우선순위 추출 API
 @router.get("/unworn/priority")
-def get_underutilized_clothes(current_season: str, db: Session = Depends(get_db)):
+def get_underutilized_clothes(current_season: SeasonEnum, db: Session = Depends(get_db)):
     current_user_id = 1 
     
     priority_clothes = (
         db.query(Clothes)
         .filter(
             Clothes.user_id == current_user_id,
-            Clothes.season == current_season
+            # 현재 계절이거나 사계절용 옷 모두 포함
+            (Clothes.season == current_season) | (Clothes.season == SeasonEnum.all_year) 
         )
         .order_by(Clothes.wear_count.asc())
         .limit(10)
         .all()
     )
     
-    return {
-        "message": f"이번 {current_season} 시즌에 우선적으로 활용할 옷을 찾았습니다.", 
-        "data": priority_clothes
-    }
+    return {"message": f"우선 추천 후보 추출 완료", "data": priority_clothes}
 
 # 착용 빈도 통계 API
 @router.get("/frequency/top")

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -20,3 +20,16 @@ def get_unworn_clothes(db: Session = Depends(get_db)):
     ).all()
     
     return {"message": f"미착용 옷 {len(unworn_clothes)}벌 조회 성공", "data": unworn_clothes}
+
+# 착용 빈도 통계 API
+@router.get("/frequency/top")
+def get_top_frequency(db: Session = Depends(get_db)):
+    current_user_id = 1
+    
+    # wear_count 기준 내림차순 정렬하여 상위 5개 추출
+    top_clothes = db.query(Clothes).filter(
+        Clothes.user_id == current_user_id,
+        Clothes.wear_count > 0
+    ).order_by(Clothes.wear_count.desc()).limit(5).all()
+    
+    return {"message": "가장 즐겨 입는 상위 5벌 조회", "data": top_clothes}

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.orm import Session
+from sqlalchemy import func  
 from typing import List
 from datetime import datetime, timedelta, date 
 from database import get_db
@@ -64,3 +65,18 @@ def get_disposal_recommendation(db: Session = Depends(get_db)):
     )
     
     return {"message": f"90일 방치 옷 {len(disposal_targets)}벌 조회 완료", "data": disposal_targets}
+
+
+# 가성비 계산 API
+@router.get("/cost-efficiency")
+def get_cost_efficiency(db: Session = Depends(get_db)):
+    current_user_id = 1
+    
+    # 가격 정보가 있고 한 번이라도 입은 옷 필터링
+    clothes = db.query(Clothes).filter(
+        Clothes.user_id == current_user_id,
+        Clothes.purchase_price > 0,
+        Clothes.wear_count > 0
+    ).all()
+
+    return {"message": f"가성비 계산 대상 {len(clothes)}벌 추출 완료"}


### PR DESCRIPTION
📌 연관 이슈
Closes #3 : 미착용 옷 추천, 빈도 통계 API 구현

Closes #4 : 가성비(CPW) 분석, 옷장 과부하 감지 기능 추가

Closes #5 : 90일 이상 방치된 옷 처분 추천 로직 구현

Closes #68 : 가성비 분석 로직 버그 수정

Closes #69 : SQLAlchemy 쿼리 리팩토링, API 라우터 연결

💡 개요
핵심 통계/분석 API 5종 구현을 완료함.

최신 main 브랜치 기준으로 Rebase를 완료하여 병합(Merge) 충돌 위험을 사전 방지함.

🛠️ 세부 구현 사항
1. 통계 및 빈도 분석 (Issue #3)
/stats/unworn/priority: 현재 계절 및 사계절용 의류를 포함하여 착용 횟수가 적은 순으로 정렬하여 반환함.

/stats/frequency/top: 착용 횟수 기준 내림차순 정렬을 통해 상위 5벌을 추출함.

2. 가성비 및 옷장 과부하 분석 (Issue #4)
/stats/cost-efficiency: models.py의 cost_per_wear 속성을 활용해 가성비 상/하위 데이터를 분리함.

/stats/overload-analysis: 카테고리 및 색상 조합이 3개 이상 중복될 경우 이를 감지하도록 GROUP BY 연산을 적용함.

3. 처분 추천 (Issue #5)
/stats/disposal-recommendation: last_worn_date 기준 90일 이상 미착용 의류를 추출함. 프론트엔드의 상태 변경 버튼(판매/기부/보관) 처리에 활용 가능함.

🚨 코드 리뷰 피드백 반영 사항
API 라우터 연결 누락 수정: main.py에 stats 및 history 라우터 등록을 추가하여 API가 정상적으로 호출되도록 조치함.

가성비 리스트 중복 노출 버그 수정: 등록된 옷이 3벌 이하일 경우 best와 worst 목록에 동일한 의류가 중복 노출되는 논리적 버그를 방지하기 위해, 예외 처리를 추가하여 worst 배열을 빈 배열로 반환하도록 개선함.

ORM 권장 문법 적용(리팩토링): 처분 추천 로직의 쿼리 필터링 시, NULL 비교 연산자를 == None에서 SQLAlchemy 권장 방식인 .is_(None)으로 변경하여 쿼리 안정성을 확보함.

⚙️ 특이사항 및 데이터 연동
DB 타입 충돌 방어: 처분 추천 로직에서 Date 및 DateTime 타입 간 비교 연산 시 발생하는 에러를 선제적으로 방어함.

AI 최적화: 프롬프트 연동을 위해 가성비 및 과부하 분석 API 응답(Response)에 ai_summary, ai_insight 객체를 포함함.