### PR TITLE
refactor: 통계 API(stats.py) DB 쿼리 성능 최적화 및 N+1 문제 해결

### DIFF
--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -75,12 +75,17 @@ def get_disposal_recommendation(db: Session = Depends(get_db)):
 def get_cost_efficiency(db: Session = Depends(get_db)):
     current_user_id = 1
     
-    # 가격 정보가 있고 한 번이라도 입은 옷 필터링
-    clothes = db.query(Clothes).filter(
-        Clothes.user_id == current_user_id,
-        Clothes.purchase_price > 0,
-        Clothes.wear_count > 0
-    ).all()
+    # DB 엔진에서 (가격 / 착용 횟수)를 직접 연산하여 오름차순으로 정렬 후 가져옴
+    clothes = (
+        db.query(Clothes)
+        .filter(
+            Clothes.user_id == current_user_id,
+            Clothes.purchase_price > 0,
+            Clothes.wear_count > 0
+        )
+        .order_by((Clothes.purchase_price / Clothes.wear_count).asc())
+        .all()
+    )
 
     sorted_clothes = sorted(clothes, key=lambda x: x.cost_per_wear)
 

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -102,17 +102,13 @@ def get_cost_efficiency(db: Session = Depends(get_db)):
 def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
     current_user_id = 1
     
-    # 카테고리/색상별 그룹화 및 threshold 이상 중복 감지
-    overloaded_groups = (
-        db.query(
-            Clothes.category, 
-            Clothes.color, 
-            func.count(Clothes.clothes_id).label("count")
-        )
+    # 1. 서브쿼리로 중복 횟수가 threshold 이상인 카테고리와 색상 조합만 찾기
+    subquery = (
+        db.query(Clothes.category, Clothes.color)
         .filter(Clothes.user_id == current_user_id)
         .group_by(Clothes.category, Clothes.color)
         .having(func.count(Clothes.clothes_id) >= threshold)
-        .all()
+        .subquery()
     )
 
     detailed_data = []

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -116,8 +116,12 @@ def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
         .join(subquery, (Clothes.category == subquery.c.category) & (Clothes.color == subquery.c.color))
         .all()
     )
-    detailed_data = [] # 임시 리스트 선언 (다음 커밋에서 데이터 조립)
-
+    grouped_data = {}
+    for item in overloaded_items:
+        key = (item.category, item.color)
+        if key not in grouped_data:
+            grouped_data[key] = []
+        grouped_data[key].append(item)
 
     return {
         "message": f"과다 보유 리포트: {len(detailed_data)}건 발견",

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -111,19 +111,12 @@ def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
         .subquery()
     )
 
-    detailed_data = []
-    for group in overloaded_groups:
-        items = db.query(Clothes).filter(
-            Clothes.user_id == current_user_id,
-            Clothes.category == group.category,
-            Clothes.color == group.color
-        ).all()
-        detailed_data.append({
-            "category": group.category,
-            "color": group.color,
-            "count": group.count,
-            "items": items
-        })
+    overloaded_items = (
+        db.query(Clothes)
+        .join(subquery, (Clothes.category == subquery.c.category) & (Clothes.color == subquery.c.color))
+        .all()
+    )
+    detailed_data = [] # 임시 리스트 선언 (다음 커밋에서 데이터 조립)
 
 
     return {

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -123,6 +123,16 @@ def get_closet_overload(threshold: int = 3, db: Session = Depends(get_db)):
             grouped_data[key] = []
         grouped_data[key].append(item)
 
+    detailed_data = [
+        {
+            "category": key[0],
+            "color": key[1],
+            "count": len(items),
+            "items": items
+        }
+        for key, items in grouped_data.items()
+    ]
+
     return {
         "message": f"과다 보유 리포트: {len(detailed_data)}건 발견",
         "overload_details": detailed_data,

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -87,16 +87,14 @@ def get_cost_efficiency(db: Session = Depends(get_db)):
         .all()
     )
 
-    sorted_clothes = sorted(clothes, key=lambda x: x.cost_per_wear)
-
-    worst_items = sorted_clothes[-3:] if len(sorted_clothes) > 3 else []
+    worst_items = clothes[-3:] if len(clothes) > 3 else []
 
     return {
         "message": "가성비 분석 완료",
-        "best_efficiency": sorted_clothes[:3], 
+        "best_efficiency": clothes[:3], 
         "worst_efficiency": worst_items, 
         "ai_summary": { 
-            "most_efficient_item": sorted_clothes[0].name if sorted_clothes else None,
+            "most_efficient_item": clothes[0].name if clothes else None,
             "total_investment_on_worst": sum(c.purchase_price for c in worst_items)
         }
     }


### PR DESCRIPTION
## 개요
데이터가 많아질 경우 발생할 수 있는 통계 및 분석 API(stats.py)의 성능 병목 현상을 선제적으로 리팩토링했습니다. 쿼리 최적화를 통해 서버와 DB의 부담을 최소화하는 데 집중했습니다.

## 작업 내용
리뷰의 편의를 위해 논리적 작업 단위에 따라 5개의 원자적 커밋(Atomic Commits)으로 나누어 반영했습니다.

1. 옷장 과부하 분석 API (/overload-analysis) 최적화

N+1 문제 해결: 기존 for 루프 내부에서 매번 DB에 접근하던 비효율적인 구조를 제거했습니다.

서브쿼리 및 JOIN 도입: 단 한 번의 쿼리로 필요한 모든 데이터를 일괄 조회하도록 아키텍처를 개선했습니다.

메모리 내 그룹화: DB에서 가져온 데이터를 파이썬 딕셔너리를 활용해 프론트엔드 규격에 맞게 효율적으로 재조립했습니다.

2. 가성비 계산 API (/cost-efficiency) 최적화

DB단 정렬 위임: 모든 옷 데이터를 메모리에 올린 뒤 정렬하던 sorted() 로직을 삭제했습니다.

order_by 연산 적용: SQLAlchemy의 order_by 내에 사칙연산을 직접 적용하여, DB 엔진이 정렬을 끝낸 결과값만 서버로 가져오도록 최적화했습니다.

## 관련 이슈
Closes #94 

### ⚠️ 추후 수정 및 협의 필요 사항 (To-Do)
- **사용자 인증 연동:** 현재 모든 통계 API에는 테스트를 위해 `current_user_id = 1`이 하드코딩되어 있습니다. 
로그인 및 JWT 토큰 기능이 완료되면 FastAPI의 `Depends`를 활용해 토큰에서 유저 ID를 동적으로 받아오도록 로직을 바로 업데이트할 예정입니다.