### PR TITLE
feat: 초기 사용자를 위한 필터링 조건 완화 및 Fallback 로직 추가

### DIFF
--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -151,6 +151,52 @@ def filter_clothes(clothes_list: list[Clothes], temperature: float, weather_cond
         result.append(c)
     return result
 
+def apply_fallback_filter(
+    all_clothes: list[Clothes],
+    temperature: float,
+    weather_condition: str,
+    situation: str = "데일리",
+) -> tuple[list[Clothes], bool]:
+    """strict filter 후 상의/하의가 2벌 미만이면 해당 카테고리의 계절·두께 필터를 해제.
+
+    옷장 규모가 작은 초기 사용자(3~5벌)도 추천을 받을 수 있도록 fallback 적용.
+    반환: (필터 결과, fallback 사용 여부)
+    """
+    MIN_PER_CATEGORY = 2
+
+    strict = filter_clothes(all_clothes, temperature, weather_condition, situation)
+
+    def _cat(c: Clothes) -> str:
+        return c.category.value if hasattr(c.category, "value") else c.category
+
+    def _is_wearable(c: Clothes) -> bool:
+        status = c.status.value if hasattr(c.status, "value") else c.status
+        return (status is None or status == StatusEnum.wearable.value) and _cat(c) != CategoryEnum.acc.value
+
+    tops    = [c for c in strict if _cat(c) == CategoryEnum.top.value]
+    bottoms = [c for c in strict if _cat(c) == CategoryEnum.bottom.value]
+
+    if len(tops) >= MIN_PER_CATEGORY and len(bottoms) >= MIN_PER_CATEGORY:
+        return strict, False
+
+    strict_ids = {c.clothes_id for c in strict}
+    result = list(strict)
+
+    if len(tops) < MIN_PER_CATEGORY:
+        for c in all_clothes:
+            if _cat(c) == CategoryEnum.top.value and c.clothes_id not in strict_ids and _is_wearable(c):
+                result.append(c)
+                strict_ids.add(c.clothes_id)
+
+    if len(bottoms) < MIN_PER_CATEGORY:
+        for c in all_clothes:
+            if _cat(c) == CategoryEnum.bottom.value and c.clothes_id not in strict_ids and _is_wearable(c):
+                result.append(c)
+                strict_ids.add(c.clothes_id)
+
+    return result, True
+
+
 def get_unworn_days(c: Clothes) -> int:
     if c.last_worn_date is None:
         return 999
@@ -291,14 +337,17 @@ def recommend_today(
         raise HTTPException(status_code=500, detail=f"옷 데이터 조회 중 오류 발생: {str(e)}")
     if len(all_clothes) < 3:
         raise HTTPException(status_code=400, detail="추천을 위해 최소 3벌 이상의 옷을 등록해주세요")
-    filtered = filter_clothes(all_clothes, temperature, weather_condition, situation or "데일리")
+    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation or "데일리")
     if len(filtered) < 2:
         return {
             "outfits": [],
             "ai_message": "날씨·상태 조건에 맞는 옷이 부족합니다"
         }
     prompt = build_prompt(filtered, situation or "daily", temperature, weather_condition, current_user)
-    return call_gemini(prompt)
+    result = call_gemini(prompt)
+    if used_fallback:
+        result["ai_message"] = "[현재 날씨·계절에 맞는 옷이 부족하여 전체 옷장 기준으로 추천했습니다] " + result.get("ai_message", "")
+    return result
 
 @router.post("/custom", response_model=RecommendResponse)
 def recommend_custom(
@@ -324,14 +373,17 @@ def recommend_custom(
         raise HTTPException(status_code=500, detail=f"옷 데이터 조회 중 오류 발생: {str(e)}")
     if len(all_clothes) < 3:
         raise HTTPException(status_code=400, detail="추천을 위해 최소 3벌 이상의 옷을 등록해주세요")
-    filtered = filter_clothes(all_clothes, temperature, weather_condition, body.situation or "데일리")
+    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, body.situation or "데일리")
     if len(filtered) < 2:
         return {
             "outfits": [],
             "ai_message": "날씨·상태 조건에 맞는 옷이 부족합니다"
         }
     prompt = build_prompt(filtered, body.situation or "daily", temperature, weather_condition, current_user)
-    return call_gemini(prompt)
+    result = call_gemini(prompt)
+    if used_fallback:
+        result["ai_message"] = "[현재 날씨·계절에 맞는 옷이 부족하여 전체 옷장 기준으로 추천했습니다] " + result.get("ai_message", "")
+    return result
 
 @router.get("/weekly")
 def recommend_weekly(

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -2,7 +2,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score
 from unittest.mock import patch
 from datetime import date, timedelta
 
@@ -153,3 +153,39 @@ class TestFilterClothesF13:
         c = make_clothes(season="사계절", status=StatusEnum.wearable)
         with patch("routers.recommend.get_current_season", return_value="봄"):
             assert c in filter_clothes([c], 20.0, "sunny")
+
+
+class TestApplyFallbackFilter:
+    def test_충분한경우_fallback미사용(self):
+        tops    = [make_clothes(category=CategoryEnum.top,    season="봄", clothes_id=i) for i in range(1, 3)]
+        bottoms = [make_clothes(category=CategoryEnum.bottom, season="봄", clothes_id=i) for i in range(3, 5)]
+        with patch("routers.recommend.get_current_season", return_value="봄"):
+            result, used = apply_fallback_filter(tops + bottoms, 20.0, "sunny")
+        assert used == False
+        assert len(result) == 4
+
+    def test_상의부족시_fallback적용(self):
+        top_spring = make_clothes(category=CategoryEnum.top,    season="봄",   clothes_id=1)
+        top_winter = make_clothes(category=CategoryEnum.top,    season="겨울", clothes_id=2)
+        bottoms    = [make_clothes(category=CategoryEnum.bottom, season="봄", clothes_id=i) for i in range(3, 5)]
+        with patch("routers.recommend.get_current_season", return_value="봄"):
+            result, used = apply_fallback_filter([top_spring, top_winter] + bottoms, 20.0, "sunny")
+        assert used == True
+        assert top_winter in result
+
+    def test_하의부족시_fallback적용(self):
+        tops          = [make_clothes(category=CategoryEnum.top,    season="봄",   clothes_id=i) for i in range(1, 3)]
+        bottom_spring = make_clothes(category=CategoryEnum.bottom, season="봄",   clothes_id=3)
+        bottom_winter = make_clothes(category=CategoryEnum.bottom, season="겨울", clothes_id=4)
+        with patch("routers.recommend.get_current_season", return_value="봄"):
+            result, used = apply_fallback_filter(tops + [bottom_spring, bottom_winter], 20.0, "sunny")
+        assert used == True
+        assert bottom_winter in result
+
+    def test_fallback에서도_착용불가_제외(self):
+        top_spring         = make_clothes(category=CategoryEnum.top, season="봄",   clothes_id=1)
+        top_winter_washing = make_clothes(category=CategoryEnum.top, season="겨울", clothes_id=2, status=StatusEnum.washing)
+        bottoms            = [make_clothes(category=CategoryEnum.bottom, season="봄", clothes_id=i) for i in range(3, 5)]
+        with patch("routers.recommend.get_current_season", return_value="봄"):
+            result, used = apply_fallback_filter([top_spring, top_winter_washing] + bottoms, 20.0, "sunny")
+        assert top_winter_washing not in result


### PR DESCRIPTION
## 개요
옷을 3~5벌만 등록한 초기 사용자가 계절·두께 필터에 의해 추천 결과를 전혀 받지 못하는 문제를 해결합니다.

## 문제 상황
기존 `filter_clothes()`는 계절 불일치(C=80) 시 해당 옷을 완전히 탈락시킵니다.
옷장에 상의가 3벌 있어도 계절 태그가 맞지 않으면 모두 탈락 → AI에 전달되는 목록이 비어
"데이터 부족" 메시지만 뜨거나 AI 로딩이 비정상적으로 길어지는 현상이 발생했습니다.

## 변경 내용
### `backend/routers/recommend.py`
- `apply_fallback_filter()` 함수 신규 추가
  - strict 필터(계절·두께·소재) 적용 후 **카테고리별(상의/하의) 결과가 2벌 미만**이면
    해당 카테고리의 계절·두께·소재 필터를 해제하고 착용 가능한 전체 목록을 AI에 전달
  - 착용불가(세탁중·수선중·보관중) 상태 필터는 fallback에서도 유지
  - fallback 발동 시 `ai_message`에 안내 문구 자동 추가
- `/recommend/today`, `/recommend/custom` 엔드포인트에 적용
- `/recommend/weekly`는 별도 필터 로직을 사용하므로 변경 없음

### `backend/tests/test_recommend.py`
- `TestApplyFallbackFilter` 클래스 추가 (4케이스)
  - 상의/하의 충분 시 fallback 미발동 확인
  - 상의 부족 시 계절 불일치 옷 fallback 포함 확인
  - 하의 부족 시 계절 불일치 옷 fallback 포함 확인
  - fallback 상황에서도 착용불가(세탁중) 옷 제외 확인

## 동작 흐름
filter_clothes() → 상의/하의 카운트
├── 상의 >= 2 AND 하의 >= 2 → 기존 동작 유지
└── 부족한 카테고리 있음 → 해당 카테고리만 필터 완화 후 AI 전달

## 테스트
- [ ] `pytest backend/tests/test_recommend.py -v` 전체 통과 확인
- [ ] 봄 기준, 여름/겨울 옷만 있는 계정으로 `/recommend/today` 호출 시 추천 정상 반환 확인
- [ ] ai_message에 fallback 안내 문구 포함 여부 확인

## 관련 이슈
- closes #131
