### PR TITLE
[Feature/Fix] 옷 등록 이미지 크롭 개선, 소재별 관리 팁 연동 및 홈 화면 무한 로딩 예외 처리

### DIFF
--- a/ClosetApp/app/(tabs)/index.tsx
+++ b/ClosetApp/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
-import AsyncStorage from '@react-native-async-storage/async-storage'; // ✨ 로그아웃을 위해 추가
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import {
@@ -113,18 +113,28 @@ export default function HomeScreen() {
 
   const [showAllOptions, setShowAllOptions] = useState<Partial<Record<keyof FilterType, boolean>>>({});
 
+  // ✅ 의존성 배열을 빈 배열([])로 설정하고 마운트 상태 락을 걸어 깜빡임/무한 로딩 버그 완벽 수정
   useFocusEffect(
     useCallback(() => {
+      let isMounted = true;
       const load = async () => {
+        if (!isMounted) return;
         setLoading(true);
-        await fetchClothes();
-        setLoading(false);
+        try {
+          await fetchClothes();
+        } catch (error) {
+          console.error("데이터 로드 실패:", error);
+        } finally {
+          if (isMounted) setLoading(false);
+        }
       };
       load();
-    }, [fetchClothes])
+      return () => {
+        isMounted = false;
+      };
+    }, [])
   );
 
-  // ✨ 로그아웃 처리 함수 추가
   const handleLogout = () => {
     Alert.alert('로그아웃', '정말 로그아웃 하시겠습니까?', [
       { text: '취소', style: 'cancel' },
@@ -250,7 +260,7 @@ export default function HomeScreen() {
   );
 
   if (loading && clothes.length === 0) {
-    return <View style={styles.loadingContainer}><ActivityIndicator size="large" /></View>;
+    return <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111" /></View>;
   }
 
   return (
@@ -262,7 +272,6 @@ export default function HomeScreen() {
             <Text style={styles.subtitle}>등록한 옷을 확인하고 관리해보세요.</Text>
           </View>
           
-          {/* ✨ 로그아웃 버튼과 추천 버튼을 나란히 배치 */}
           <View style={styles.headerActionBox}>
             <TouchableOpacity style={styles.logoutBtn} onPress={handleLogout}>
               <Text style={styles.logoutText}>로그아웃</Text>
@@ -273,58 +282,73 @@ export default function HomeScreen() {
           </View>
         </View>
 
-        <View style={styles.actionRow}>
-          <TouchableOpacity style={[styles.primaryActionBtn, showFilter && styles.primaryActionBtnActive]} onPress={() => setShowFilter((prev) => !prev)} activeOpacity={0.85}>
-            <Ionicons name={showFilter ? 'close-outline' : 'options-outline'} size={18} color="#fff" style={styles.primaryActionIcon} />
-            <Text style={styles.primaryActionText}>{showFilter ? '닫기' : '필터'}</Text>
-          </TouchableOpacity>
-          {activeFilterCount > 0 && (
-            <TouchableOpacity style={styles.secondaryActionBtn} onPress={resetFilters} activeOpacity={0.85}>
-              <Text style={styles.secondaryActionText}>초기화 {activeFilterCount}</Text>
+        {/* ✅ 옷이 없을 때는 빈 화면(Empty State) 렌더링 */}
+        {clothes.length === 0 ? (
+          <View style={styles.emptyStateContainer}>
+            <Ionicons name="shirt-outline" size={64} color="#d1d5db" />
+            <Text style={styles.emptyStateTitle}>등록된 옷이 없습니다</Text>
+            <Text style={styles.emptyStateDesc}>첫 번째 옷을 등록하고 스마트한 옷장을 시작해보세요!</Text>
+            <TouchableOpacity style={styles.emptyStateBtn} onPress={() => router.push('/(tabs)/register')}>
+              <Text style={styles.emptyStateBtnText}>옷 등록하러 가기</Text>
             </TouchableOpacity>
-          )}
-        </View>
+          </View>
+        ) : (
+          /* ✅ 문법 에러가 났던 </></> 오타를 정식 Fragment 태그인 </> 로 완벽히 교정 */
+          <>
+            <View style={styles.actionRow}>
+              <TouchableOpacity style={[styles.primaryActionBtn, showFilter && styles.primaryActionBtnActive]} onPress={() => setShowFilter((prev) => !prev)} activeOpacity={0.85}>
+                <Ionicons name={showFilter ? 'close-outline' : 'options-outline'} size={18} color="#fff" style={styles.primaryActionIcon} />
+                <Text style={styles.primaryActionText}>{showFilter ? '닫기' : '필터'}</Text>
+              </TouchableOpacity>
+              {activeFilterCount > 0 && (
+                <TouchableOpacity style={styles.secondaryActionBtn} onPress={resetFilters} activeOpacity={0.85}>
+                  <Text style={styles.secondaryActionText}>초기화 {activeFilterCount}</Text>
+                </TouchableOpacity>
+              )}
+            </View>
 
-        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.typeScrollContent} style={styles.typeScroll}>
-          {CATEGORY_ORDER.map((type) => (
-            <TouchableOpacity key={type} style={[styles.typeBtn, selectedType === type && styles.typeBtnSelected]} onPress={() => setSelectedType(type)} activeOpacity={0.85}>
-              <Text style={[styles.typeText, selectedType === type && styles.typeTextSelected]}>{type}</Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
-
-        {showFilter && (
-          <View style={styles.filterPanel}>
-            <ScrollView ref={filterScrollRef} horizontal pagingEnabled showsHorizontalScrollIndicator={false} onMomentumScrollEnd={handleFilterPageChange}>
-              {FILTER_SECTIONS.map((section, index) => (
-                <View key={index} style={{ width: width - 32 }}>
-                  <View style={styles.filterSectionCard}>
-                    <Text style={styles.filterSectionTitle}>{section.title}</Text>
-                    {section.items.map((sectionItem, idx) => (
-                      <View key={idx}>
-                        {renderSection(sectionItem.label, sectionItem.key, sectionItem.options)}
-                      </View>
-                    ))}
-                  </View>
-                </View>
+            <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.typeScrollContent} style={styles.typeScroll}>
+              {CATEGORY_ORDER.map((type) => (
+                <TouchableOpacity key={type} style={[styles.typeBtn, selectedType === type && styles.typeBtnSelected]} onPress={() => setSelectedType(type)} activeOpacity={0.85}>
+                  <Text style={[styles.typeText, selectedType === type && styles.typeTextSelected]}>{type}</Text>
+                </TouchableOpacity>
               ))}
             </ScrollView>
-            <View style={styles.paginationWrap}>
-              {FILTER_SECTIONS.map((_, index) => (
-                <View key={index} style={[styles.paginationDot, currentFilterPage === index && styles.paginationDotActive]} />
-              ))}
+
+            {showFilter && (
+              <View style={styles.filterPanel}>
+                <ScrollView ref={filterScrollRef} horizontal pagingEnabled showsHorizontalScrollIndicator={false} onMomentumScrollEnd={handleFilterPageChange}>
+                  {FILTER_SECTIONS.map((section, index) => (
+                    <View key={index} style={{ width: width - 32 }}>
+                      <View style={styles.filterSectionCard}>
+                        <Text style={styles.filterSectionTitle}>{section.title}</Text>
+                        {section.items.map((sectionItem, idx) => (
+                          <View key={idx}>
+                            {renderSection(sectionItem.label, sectionItem.key, sectionItem.options)}
+                          </View>
+                        ))}
+                      </View>
+                    </View>
+                  ))}
+                </ScrollView>
+                <View style={styles.paginationWrap}>
+                  {FILTER_SECTIONS.map((_, index) => (
+                    <View key={index} style={[styles.paginationDot, currentFilterPage === index && styles.paginationDotActive]} />
+                  ))}
+                </View>
+              </View>
+            )}
+
+            <View style={styles.resultHeader}>
+              <Text style={styles.resultTitle}>옷 목록</Text>
+              <Text style={styles.resultCount}>{filteredClothes.length}개</Text>
             </View>
-          </View>
+
+            <View style={styles.grid}>
+              {filteredClothes.map((item) => renderCard(item))}
+            </View>
+          </>
         )}
-
-        <View style={styles.resultHeader}>
-          <Text style={styles.resultTitle}>옷 목록</Text>
-          <Text style={styles.resultCount}>{filteredClothes.length}개</Text>
-        </View>
-
-        <View style={styles.grid}>
-          {filteredClothes.map((item) => renderCard(item))}
-        </View>
       </ScrollView>
 
       <Modal visible={menuVisible} transparent animationType="fade" onRequestClose={closeMenu}>
@@ -351,13 +375,12 @@ const styles = StyleSheet.create({
   title: { fontSize: 28, fontWeight: '800', marginBottom: 6, color: '#111' },
   subtitle: { fontSize: 14, color: '#6b6b6b', lineHeight: 20 },
   
-  /* ✨ 버튼 그룹 스타일 추가 */
   headerActionBox: { flexDirection: 'row', gap: 6, alignItems: 'center' },
   logoutBtn: { backgroundColor: '#fff', paddingVertical: 9, paddingHorizontal: 12, borderRadius: 12, borderWidth: 1, borderColor: '#ffcccc' },
   logoutText: { color: '#d11a2a', fontSize: 13, fontWeight: '700' },
-  
   moveRecommendBtn: { backgroundColor: '#f3f3f3', paddingVertical: 9, paddingHorizontal: 14, borderRadius: 12, borderWidth: 1, borderColor: '#e4e4e4' },
   moveRecommendText: { color: '#222', fontSize: 13, fontWeight: '700' },
+  
   actionRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 12, gap: 8 },
   primaryActionBtn: { backgroundColor: '#111', paddingVertical: 11, paddingHorizontal: 14, borderRadius: 14, flexDirection: 'row', alignItems: 'center' },
   primaryActionBtnActive: { backgroundColor: '#333' },
@@ -402,6 +425,13 @@ const styles = StyleSheet.create({
   tpoTag: { backgroundColor: '#eef2ff', color: '#4f46e5' },
   cardHint: { fontSize: 11, color: '#7a7a7a', marginTop: 8 },
   loadingContainer: { flex: 1, backgroundColor: '#fff', justifyContent: 'center', alignItems: 'center' },
+  
+  emptyStateContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', marginTop: 80 },
+  emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#111', marginTop: 16, marginBottom: 8 },
+  emptyStateDesc: { fontSize: 14, color: '#6b7280', textAlign: 'center', marginBottom: 24, paddingHorizontal: 20 },
+  emptyStateBtn: { backgroundColor: '#111', paddingVertical: 14, paddingHorizontal: 24, borderRadius: 12 },
+  emptyStateBtnText: { color: '#fff', fontSize: 15, fontWeight: '700' },
+
   modalOverlay: { flex: 1, backgroundColor: 'rgba(0,0,0,0.35)', justifyContent: 'center', alignItems: 'center', padding: 24 },
   modalBox: { width: '100%', backgroundColor: '#fff', borderRadius: 20, padding: 18 },
   modalTitle: { fontSize: 18, fontWeight: '800', marginBottom: 14, textAlign: 'center', color: '#111' },

--- a/ClosetApp/app/(tabs)/register.tsx
+++ b/ClosetApp/app/(tabs)/register.tsx
@@ -202,7 +202,8 @@ export default function RegisterScreen() {
     <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       <Text style={styles.title}>옷 등록</Text>
       <TouchableOpacity style={styles.imageBox} onPress={pickImage}>
-        {image ? <Image source={{ uri: image }} style={styles.image} resizeMode="cover" /> : <Text style={styles.imagePlaceholder}>+ 사진 추가</Text>}
+        {/* ✅ 수정 포인트: resizeMode를 contain으로 수정하여 이미지 상/하단 짤림 해결 */}
+        {image ? <Image source={{ uri: image }} style={styles.image} resizeMode="contain" /> : <Text style={styles.imagePlaceholder}>+ 사진 추가</Text>}
       </TouchableOpacity>
       <Text style={styles.sectionTitle}>카테고리</Text>
       {renderChips(TAG_OPTIONS.category, 'category')}
@@ -245,6 +246,7 @@ const styles = StyleSheet.create({
   content: { padding: 16, paddingBottom: 32 },
   title: { fontSize: 26, fontWeight: '700', marginBottom: 16 },
   imageBox: { height: 220, borderRadius: 16, backgroundColor: '#f3f4f6', justifyContent: 'center', alignItems: 'center', overflow: 'hidden', marginBottom: 20 },
+  // ✅ 배경색을 한 번 더 선언하여 원본 비율 매핑 시 좌우 여백을 자연스럽게 처리
   image: { width: '100%', height: '100%', backgroundColor: '#f3f4f6' },
   imagePlaceholder: { color: '#6b7280', fontSize: 16, fontWeight: '600' },
   sectionTitle: { fontSize: 16, fontWeight: '700', marginTop: 10, marginBottom: 8 },

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -1,5 +1,5 @@
 import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
@@ -14,7 +14,18 @@ import api from './_api';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
 
-// ✅ 빨간 줄 에러를 해결하기 위해 최상위에 situation, tpo 추가
+// ✅ 1. 관리 팁 데이터를 위한 타입 정의 추가
+interface CareTip {
+  "세탁 및 관리": string;
+  "보관 방법": string;
+}
+
+interface TipResponse {
+  clothes_name: string;
+  material: string;
+  tip: CareTip | string;
+}
+
 type DetailApiItem = {
   id?: number;
   clothes_id?: number;
@@ -47,6 +58,7 @@ type DetailApiItem = {
   color?: string;
   season?: string;
   style?: string;
+  material?: string; // 소재 정보 추가 매핑용
 };
 
 function resolveImageUri(image?: string | null) {
@@ -63,6 +75,10 @@ export default function DetailScreen() {
   const [item, setItem] = useState<DetailApiItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
+
+  // ✅ 2. 관리 팁 상태 변수 추가
+  const [tipData, setTipData] = useState<TipResponse | null>(null);
+  const [tipLoading, setTipLoading] = useState(false);
 
   const fetchDetail = useCallback(async () => {
     if (!id) {
@@ -109,13 +125,33 @@ export default function DetailScreen() {
     }, [fetchDetail])
   );
 
+  // ✅ 3. 옷 상세 정보(item)를 성공적으로 가져오면 관리 팁 API 호출
+  useEffect(() => {
+    const fetchCareTips = async () => {
+      const actualId = item?.id ?? item?.clothes_id;
+      if (!actualId) return;
+
+      try {
+        setTipLoading(true);
+        const response = await api.get<TipResponse>(`/clothes/${actualId}/tips`);
+        setTipData(response.data);
+      } catch (error) {
+        console.error("소재별 관리 팁 로드 실패:", error);
+        setTipData(null);
+      } finally {
+        setTipLoading(false);
+      }
+    };
+
+    fetchCareTips();
+  }, [item?.id, item?.clothes_id]); // ID가 확보될 때만 실행
+
   const visibleTags = useMemo(() => {
     if (!item) return [];
 
     const s = item.tags || {};
     const fitValue = s.top_fit ?? s.topFit ?? s.bottom_fit ?? s.bottomFit ?? '';
     
-    // ✅ 에러 없이 안전하게 호출 가능
     const tpoValue = s.situation ?? s.tpo ?? item.situation ?? item.tpo ?? '';
     
     const rawPrice = item.price ?? item.purchase_price;
@@ -132,7 +168,7 @@ export default function DetailScreen() {
       { label: '스타일', value: s.style ?? item.style },
       { label: '분위기', value: s.mood },
       { label: '핏', value: fitValue },
-      { label: '소재', value: s.material },
+      { label: '소재', value: s.material ?? item.material },
       { label: '두께', value: s.thickness },
       { label: '포인트', value: s.point },
       { label: 'TPO', value: tpoValue },
@@ -149,7 +185,7 @@ export default function DetailScreen() {
   if (loading && !item) {
     return (
       <View style={styles.emptyContainer}>
-        <ActivityIndicator size="large" />
+        <ActivityIndicator size="large" color="#111827" />
         <Text style={styles.emptyText}>상세 정보를 불러오는 중...</Text>
       </View>
     );
@@ -192,6 +228,30 @@ export default function DetailScreen() {
         </View>
       )}
 
+      {/* ✅ 4. 관리 팁 UI 섹션 추가 (태그 리스트와 수정 버튼 사이) */}
+      {tipLoading ? (
+        <ActivityIndicator size="small" color="#111827" style={{ marginBottom: 20 }} />
+      ) : tipData ? (
+        <View style={styles.tipContainer}>
+          <Text style={styles.tipTitle}>💡 {tipData.material} 소재 관리 팁</Text>
+          
+          {typeof tipData.tip === 'object' ? (
+            <>
+              <View style={styles.tipBox}>
+                <Text style={styles.tipLabel}>🧼 세탁 및 관리</Text>
+                <Text style={styles.tipValueText}>{tipData.tip["세탁 및 관리"]}</Text>
+              </View>
+              <View style={styles.tipBox}>
+                <Text style={styles.tipLabel}>📦 보관 방법</Text>
+                <Text style={styles.tipValueText}>{tipData.tip["보관 방법"]}</Text>
+              </View>
+            </>
+          ) : (
+            <Text style={styles.errorTipText}>{tipData.tip}</Text>
+          )}
+        </View>
+      ) : null}
+
       <TouchableOpacity
         style={styles.button}
         onPress={() => router.push({ 
@@ -220,6 +280,15 @@ const styles = StyleSheet.create({
   tagLabel: { width: 88, fontSize: 14, color: '#6b7280' },
   tagPill: { flexShrink: 1, backgroundColor: '#111827', borderRadius: 999, paddingVertical: 7, paddingHorizontal: 12 },
   tagText: { color: '#fff', fontSize: 14 },
+  
+  // ✅ 5. 관리 팁 관련 스타일
+  tipContainer: { backgroundColor: '#f9fafb', padding: 16, borderRadius: 12, marginBottom: 20, borderWidth: 1, borderColor: '#e5e7eb' },
+  tipTitle: { fontSize: 16, fontWeight: '700', marginBottom: 12, color: '#111827' },
+  tipBox: { marginBottom: 12 },
+  tipLabel: { fontSize: 14, fontWeight: '600', color: '#374151', marginBottom: 4 },
+  tipValueText: { fontSize: 14, color: '#4b5563', lineHeight: 20 },
+  errorTipText: { fontSize: 14, color: '#6b7280', fontStyle: 'italic', lineHeight: 20 },
+
   button: { marginTop: 8, backgroundColor: '#111827', paddingVertical: 16, borderRadius: 12, alignItems: 'center' },
   buttonText: { color: '#fff', fontWeight: '700', fontSize: 16 },
 });


### PR DESCRIPTION
## 개요
- 옷 등록 화면에서 의류 이미지가 상/하단 크롭되는 현상을 개선하여 원본 비율을 유지하도록 수정했습니다.
- 백엔드 MVP 스펙인 소재별 관리 팁(GET /clothes/{id}/tips) 엔드포인트를 프론트엔드 상세 화면(`detail.tsx`)에 최종 연동했습니다.
- 회원가입 직후(의류 데이터 공백 상태) 홈 화면 진입 시 무한 로딩이 걸리거나 0.1초 간격으로 무한 깜빡임이 발생하던 렌더링 동결 버그를 수정했습니다.

## 주요 변경 사항
### 1. 이미지 짤림 현상 개선
- 옷 등록 화면 등의 이미지 미리보기 컴포넌트 속성을 기존 `resizeMode="cover"`에서 `resizeMode="contain"`으로 변경했습니다.
- 이로 인해 긴 의류(바지, 아우터 등)의 상/하단 영역이 잘려 나가지 않고 온전한 비율로 렌더링되도록 수정했습니다.

### 2. 소재별 관리 팁 UI 구축 및 API 연동 (`app/detail.tsx`)
- 태그 리스트 하단 영역에 백엔드에서 제공하는 11가지 소재별(니트, 데님, 코튼 등) 맞춤형 가이드(세탁 및 관리 / 보관 방법)를 출력하는 전용 카드 섹션을 구축했습니다.
- 소재 정보가 없거나 예외 상황일 경우 백엔드의 폴백 안내 메시지가 가독성 있게 매핑되도록 처리했습니다.

### 3. 홈 화면 무한 로딩 및 깜빡임 버그 예외 처리 (`app/(tabs)/index.tsx`)
- **무한 깜빡임 원인 차단**: `useFocusEffect` 내부에서 `fetchClothes` 상태 변화가 발생할 때마다 화면이 무한 재트리거(Infinite Re-trigger)되던 의존성 문제를 의존성 배열 격리(`[]`) 및 마운트 락(`isMounted`) 구조로 해결했습니다.
- **데이터 공백 상태(Empty State) 예외 처리**: 등록된 옷이 0개(빈 배열)일 때 스피너에 갇히지 않고 로딩이 안전하게 풀리도록 로직을 보완하고, "등록된 옷이 없습니다" 안내 문구와 함께 `옷 등록하러 가기` 네비게이션 버튼이 동작하는 공백 화면 UI를 연동했습니다.
- **JSX 문법 교정**: Fragment 타포 분리 과정에서 생긴 코드 오타(`</</>`)를 `</>`로 정상 복구하여 빌드 안정성을 확보했습니다.

## 관련 이슈
- Closes #161
- Closes #162
- Closes #163

## 테스트 결과
- [x] 의류 이미지 등록 및 미리보기 시 원본 비율 유지 및 짤림 현상 개선 완료
- [x] 옷 상세 페이지에서 각 소재 태그(니트, 데님 등)에 맞는 세탁/보관 관리 팁 데이터 정상 바인딩 및 예외 처리 검증 완료
- [x] 신규 계정 진입 시 무한 스피너 및 깜빡임 없이 Empty State UI(바로가기 버튼 포함)가 부드럽게 출력되는지 검증 완료