### PR TITLE
refactor: fetch_weather() 자기 서버 HTTP 호출 구조 개선 (Issue #143)

### DIFF
--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -1,7 +1,6 @@
 import os
 import json
 import re
-import httpx
 import google.generativeai as genai
 from dotenv import load_dotenv
 from datetime import date
@@ -14,6 +13,7 @@ from database import get_db
 from models import Clothes, CategoryEnum, StatusEnum, User, ThicknessEnum
 from routers.auth import get_current_user
 from tpo_rules import get_tpo_prompt_text, check_color_conflict
+from utils import get_weather_data
 
 # .env 파일 로드
 load_dotenv()
@@ -24,8 +24,6 @@ router = APIRouter(prefix="/recommend", tags=["코디 추천"])
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY")
 genai.configure(api_key=GEMINI_API_KEY)
 model = genai.GenerativeModel("models/gemini-flash-latest")
-
-WEATHER_BASE_URL = os.getenv("WEATHER_BASE_URL", "http://localhost:8000")
 
 # --- 데이터 모델 정의 ---
 class RecommendRequest(BaseModel):
@@ -52,35 +50,7 @@ class RecommendResponse(BaseModel):
 # --- 유틸리티 함수 ---
 def fetch_weather(address: str) -> dict:
     try:
-        with httpx.Client(timeout=5.0) as client:
-            resp = client.get(
-                f"{WEATHER_BASE_URL}/weather/address",
-                params={"address": address}
-            )
-            resp.raise_for_status()
-            data = resp.json()
-
-        if data.get("status") != "success":
-            return {"temperature": 20.0, "condition": "sunny"}
-
-        weather = data["weather"]
-        temp_str = weather.get("현재 기온", "20°C").replace("°C", "").strip()
-        temperature = float(temp_str)
-
-        sky  = weather.get("하늘 상태", "맑음")
-        rain = weather.get("강수 형태", "없음")
-
-        if rain in ("비", "소나기", "비/눈"):
-            condition = "rainy"
-        elif rain == "눈":
-            condition = "snowy"
-        elif sky == "맑음":
-            condition = "sunny"
-        else:
-            condition = "cloudy"
-
-        return {"temperature": temperature, "condition": condition}
-
+        return get_weather_data(address)
     except Exception as e:
         print(f"[날씨 연동 실패, 기본값 사용] {e}")
         return {"temperature": 20.0, "condition": "sunny"}

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,7 +1,7 @@
 import pytest
 from datetime import datetime
 from unittest.mock import patch
-from utils import get_base_time 
+from utils import get_base_time, get_weather_data
 
 def test_get_base_time_midnight_edge_case():
     """
@@ -50,3 +50,49 @@ def test_get_base_time_normal_daytime():
         assert base_date == "20260520"  # 당일 날짜 유지
         # 시스템에 정의된 base_times 규칙(예: 0200, 0500 등) 중 06시 직전 최적 타임라인 검증
         assert base_time == "0500"
+
+
+class TestGetWeatherData:
+    def _make_api_response(self, temp, sky, pty):
+        return {
+            "response": {
+                "header": {"resultCode": "00"},
+                "body": {"items": {"item": [
+                    {"category": "TMP", "fcstValue": str(temp)},
+                    {"category": "SKY", "fcstValue": str(sky)},
+                    {"category": "PTY", "fcstValue": str(pty)},
+                ]}}
+            }
+        }
+
+    def test_맑은날_sunny반환(self):
+        with patch("utils.get_coords_from_address", return_value=(37.5, 127.0)), \
+             patch("utils.convert_grid", return_value=(60, 127)), \
+             patch("utils.get_base_time", return_value=("20260527", "0800")), \
+             patch("utils.requests.get") as mock_get:
+            mock_get.return_value.json.return_value = self._make_api_response(18, 1, 0)
+            result = get_weather_data("서울시 강남구")
+        assert result["temperature"] == 18.0
+        assert result["condition"] == "sunny"
+
+    def test_비오는날_rainy반환(self):
+        with patch("utils.get_coords_from_address", return_value=(37.5, 127.0)), \
+             patch("utils.convert_grid", return_value=(60, 127)), \
+             patch("utils.get_base_time", return_value=("20260527", "0800")), \
+             patch("utils.requests.get") as mock_get:
+            mock_get.return_value.json.return_value = self._make_api_response(15, 4, 1)
+            result = get_weather_data("서울시 강남구")
+        assert result["condition"] == "rainy"
+
+    def test_유효하지않은주소_기본값반환(self):
+        with patch("utils.get_coords_from_address", return_value=(None, None)):
+            result = get_weather_data("존재하지않는주소xxxxxx")
+        assert result == {"temperature": 20.0, "condition": "sunny"}
+
+    def test_API호출실패_기본값반환(self):
+        with patch("utils.get_coords_from_address", return_value=(37.5, 127.0)), \
+             patch("utils.convert_grid", return_value=(60, 127)), \
+             patch("utils.get_base_time", return_value=("20260527", "0800")), \
+             patch("utils.requests.get", side_effect=Exception("network error")):
+            result = get_weather_data("서울시 강남구")
+        assert result == {"temperature": 20.0, "condition": "sunny"}

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,5 +1,6 @@
 from datetime import datetime, timedelta
 import math
+import os
 import requests
 
 # 1. 주소 -> 위경도 변환 (OpenStreetMap Nominatim 사용)
@@ -76,7 +77,75 @@ def get_base_time():
     if closest_time == 23 and current_hour != 23:
         base_date = (check_time - timedelta(days=1)).strftime("%Y%m%d")
 
-    # 정수형 예보 시간을 기상청 포맷(HH00) 문자열로 가공        
+    # 정수형 예보 시간을 기상청 포맷(HH00) 문자열로 가공
     base_time = f"{closest_time:02d}00"
-        
+
     return base_date, base_time
+
+
+def get_weather_data(address: str) -> dict:
+    """주소로 기상청 단기예보 API를 직접 호출해 기온·날씨 조건을 반환.
+    실패 또는 유효하지 않은 주소면 기본값 {'temperature': 20.0, 'condition': 'sunny'}을 반환한다.
+    recommend.py의 fetch_weather()가 자기 서버 HTTP를 호출하는 구조를 제거하기 위해 추가됨.
+    """
+    service_key = os.getenv("WEATHER_SERVICE_KEY")
+
+    lat, lon = get_coords_from_address(address)
+    if lat is None:
+        return {"temperature": 20.0, "condition": "sunny"}
+
+    nx, ny = convert_grid(lat, lon)
+    base_date, base_time = get_base_time()
+
+    url = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+    params = {
+        "serviceKey": service_key,
+        "pageNo": "1",
+        "numOfRows": "200",
+        "dataType": "JSON",
+        "base_date": base_date,
+        "base_time": base_time,
+        "nx": nx,
+        "ny": ny,
+    }
+
+    try:
+        response = requests.get(url, params=params, timeout=5)
+        res_data = response.json()
+
+        if res_data.get("response", {}).get("header", {}).get("resultCode") != "00":
+            return {"temperature": 20.0, "condition": "sunny"}
+
+        items = res_data["response"]["body"]["items"]["item"]
+        sky_map = {"1": "맑음", "3": "구름많음", "4": "흐림"}
+        pty_map = {"0": "없음", "1": "비", "2": "비/눈", "3": "눈", "4": "소나기"}
+
+        current_temp, sky, rain = None, None, None
+        for item in items:
+            cat, val = item["category"], item["fcstValue"]
+            if cat == "TMP" and current_temp is None:
+                current_temp = float(val)
+            elif cat == "SKY" and sky is None:
+                sky = sky_map.get(val, "맑음")
+            elif cat == "PTY" and rain is None:
+                rain = pty_map.get(val, "없음")
+            if current_temp is not None and sky is not None and rain is not None:
+                break
+
+        temperature = current_temp if current_temp is not None else 20.0
+        sky = sky or "맑음"
+        rain = rain or "없음"
+
+        if rain in ("비", "소나기", "비/눈"):
+            condition = "rainy"
+        elif rain == "눈":
+            condition = "snowy"
+        elif sky == "맑음":
+            condition = "sunny"
+        else:
+            condition = "cloudy"
+
+        return {"temperature": temperature, "condition": condition}
+
+    except Exception:
+        return {"temperature": 20.0, "condition": "sunny"}


### PR DESCRIPTION
## 변경 사항

- `recommend.py`의 `fetch_weather()`가 자기 자신의 `/weather/address` 엔드포인트에 HTTP 요청을 보내는 구조를 제거
- `utils.py`에 `get_weather_data(address)` 함수 추가 — 기상청 API를 직접 호출
- `fetch_weather()`가 `get_weather_data()`를 직접 호출하도록 교체
- 불필요한 `httpx` import 및 `WEATHER_BASE_URL` 환경변수 제거

## 테스트

- `tests/test_utils.py`에 `get_weather_data()` 단위 테스트 4케이스 추가
  - 맑은 날 sunny 반환
  - 비 오는 날 rainy 반환
  - 유효하지 않은 주소 → 기본값 반환
  - API 호출 실패 → 기본값 반환

Closes #143