### PR TITLE
feat: 피드백 TpoScore 기반 추천 필터 연동

### DIFF
--- a/backend/routers/feedback.py
+++ b/backend/routers/feedback.py
@@ -1,12 +1,37 @@
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.orm import Session
-from routers.auth import get_current_user  
+from routers.auth import get_current_user
 
 from database import get_db
-from models import WearHistory, Clothes, User, TpoScore  
-from schemas import FeedbackCreate, FeedbackTempEnum, FeedbackTpoEnum 
+from models import WearHistory, Clothes, User, TpoScore
+from schemas import FeedbackCreate, FeedbackTempEnum, FeedbackTpoEnum
 
 router = APIRouter(prefix="/feedback", tags=["피드백"])
+
+
+def update_tpo_score(db: Session, clothes_id: int, situation: str, feedback_tpo) -> None:
+    """TpoScore 업데이트: bad → -5 (하한 0), good → +5 (상한 100)"""
+    tpo_score_rec = db.query(TpoScore).filter(
+        TpoScore.clothes_id == clothes_id,
+        TpoScore.tpo_name == situation
+    ).first()
+    if feedback_tpo == FeedbackTpoEnum.bad:
+        if not tpo_score_rec:
+            db.add(TpoScore(clothes_id=clothes_id, tpo_name=situation, score=95))
+        else:
+            tpo_score_rec.score = max(0, tpo_score_rec.score - 5)
+    elif feedback_tpo == FeedbackTpoEnum.good:
+        if tpo_score_rec:
+            tpo_score_rec.score = min(100, tpo_score_rec.score + 5)
+
+
+def update_temp_sensitivity(user, feedback_temp) -> None:
+    """온도 민감도 보정: cold → +0.5, hot → -0.5, 범위 -2.0~2.0"""
+    current = user.temp_sensitivity or 0.0
+    if feedback_temp == FeedbackTempEnum.cold:
+        user.temp_sensitivity = max(-2.0, min(2.0, current + 0.5))
+    elif feedback_temp == FeedbackTempEnum.hot:
+        user.temp_sensitivity = max(-2.0, min(2.0, current - 0.5))
 
 @router.post("", status_code=status.HTTP_200_OK)
 def create_feedback(
@@ -40,42 +65,13 @@ def create_feedback(
     # 3. 데이터 업데이트
     if feedback_data.feedback_temperature is not None:
         history.feedback_temperature = feedback_data.feedback_temperature
-        
-        # current_user를 직접 사용하여 로직 간소화
-        current_sensitivity = current_user.temp_sensitivity or 0.0
-        
-        # 보정 가중치를 0.5로 최적화하고, 범위를 -2.0 ~ 2.0 사이로 제한(Clamp)
-        if feedback_data.feedback_temperature == FeedbackTempEnum.cold:
-            new_val = current_sensitivity + 0.5
-            current_user.temp_sensitivity = max(-2.0, min(2.0, new_val))
-        elif feedback_data.feedback_temperature == FeedbackTempEnum.hot:
-            new_val = current_sensitivity - 0.5
-            current_user.temp_sensitivity = max(-2.0, min(2.0, new_val))
-        elif feedback_data.feedback_temperature == FeedbackTempEnum.good:
-            current_user.temp_sensitivity = current_sensitivity
+        update_temp_sensitivity(current_user, feedback_data.feedback_temperature)
 
-    
     if feedback_data.feedback_tpo is not None:
         history.feedback_tpo = feedback_data.feedback_tpo
         situation = history.tpo.value if hasattr(history.tpo, 'value') else history.tpo
-        
         if situation and cloth:
-            tpo_score_rec = db.query(TpoScore).filter(
-                TpoScore.clothes_id == cloth.clothes_id,
-                TpoScore.tpo_name == situation
-            ).first()
-
-            # [점수 보정 로직]
-            if feedback_data.feedback_tpo == FeedbackTpoEnum.bad:
-                if not tpo_score_rec:
-                    db.add(TpoScore(clothes_id=cloth.clothes_id, tpo_name=situation, score=95))
-                else:
-                    tpo_score_rec.score = max(0, tpo_score_rec.score - 5)
-            
-            # '적합' 피드백 시 점수 회복 로직 추가 (최대 100점)
-            elif feedback_data.feedback_tpo == FeedbackTpoEnum.good:
-                if tpo_score_rec:
-                    tpo_score_rec.score = min(100, tpo_score_rec.score + 5)
+            update_tpo_score(db, cloth.clothes_id, situation, feedback_data.feedback_tpo)
 
 
     if feedback_data.memo is not None:

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -244,7 +244,7 @@ def build_prompt(clothes_list: list[Clothes], situation: str, temperature: float
     situation_map = {
         "daily": "데일리", "business": "비즈니스", "interview": "면접",
         "wedding": "결혼식", "funeral": "장례식", "exercise": "운동",
-        "date": "데이트", "meeting": "모임", "travel": "여행",
+        "date": "데이트", "meeting": "미팅", "travel": "여행",
         "school": "데일리", "cafe": "데일리",
     }
     situation_kr = situation_map.get(situation or "daily", situation or "데일리")
@@ -327,7 +327,7 @@ def call_gemini(prompt: str, retries: int = 2) -> dict:
 SITUATION_MAP = {
     "daily": "데일리", "business": "비즈니스", "interview": "면접",
     "wedding": "결혼식", "funeral": "장례식", "exercise": "운동",
-    "date": "데이트", "meeting": "모임", "travel": "여행",
+    "date": "데이트", "meeting": "미팅", "travel": "여행",
     "school": "데일리", "cafe": "데일리",
 }
 

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -130,7 +130,15 @@ def calculate_conflict_score(c: Clothes, situation: str) -> int:
     return 0
 
 
-def filter_clothes(clothes_list: list[Clothes], temperature: float, weather_condition: str, situation: str = "데일리") -> list[Clothes]:
+def filter_clothes(
+    clothes_list: list[Clothes],
+    temperature: float,
+    weather_condition: str,
+    situation: str = "데일리",
+    tpo_scores: dict[int, int] | None = None,
+) -> list[Clothes]:
+    if tpo_scores is None:
+        tpo_scores = {}
     result = []
     for c in clothes_list:
         if c.status is not None and c.status != StatusEnum.wearable.value:
@@ -148,6 +156,9 @@ def filter_clothes(clothes_list: list[Clothes], temperature: float, weather_cond
         # F-13: 계절 불일치(C=80) 제외
         if calculate_conflict_score(c, situation) >= 80:
             continue
+        # 피드백 누적 TpoScore 60 미만 옷 제외 (8회 이상 부정 피드백)
+        if tpo_scores.get(c.clothes_id, 100) < 60:
+            continue
         result.append(c)
     return result
 
@@ -156,15 +167,18 @@ def apply_fallback_filter(
     temperature: float,
     weather_condition: str,
     situation: str = "데일리",
+    tpo_scores: dict[int, int] | None = None,
 ) -> tuple[list[Clothes], bool]:
     """strict filter 후 상의/하의가 2벌 미만이면 해당 카테고리의 계절·두께 필터를 해제.
 
     옷장 규모가 작은 초기 사용자(3~5벌)도 추천을 받을 수 있도록 fallback 적용.
     반환: (필터 결과, fallback 사용 여부)
     """
+    if tpo_scores is None:
+        tpo_scores = {}
     MIN_PER_CATEGORY = 2
 
-    strict = filter_clothes(all_clothes, temperature, weather_condition, situation)
+    strict = filter_clothes(all_clothes, temperature, weather_condition, situation, tpo_scores)
 
     def _cat(c: Clothes) -> str:
         return c.category.value if hasattr(c.category, "value") else c.category

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -241,13 +241,7 @@ def clothes_to_text(c: Clothes) -> str:
     )
 
 def build_prompt(clothes_list: list[Clothes], situation: str, temperature: float, weather_condition: str, user: User) -> str:
-    situation_map = {
-        "daily": "데일리", "business": "비즈니스", "interview": "면접",
-        "wedding": "결혼식", "funeral": "장례식", "exercise": "운동",
-        "date": "데이트", "meeting": "미팅", "travel": "여행",
-        "school": "데일리", "cafe": "데일리",
-    }
-    situation_kr = situation_map.get(situation or "daily", situation or "데일리")
+    situation_kr = to_situation_kr(situation)
     context = get_tpo_prompt_text(situation_kr, temperature, weather_condition)
     profile_text, preferred_style, felt_temp, outer_threshold = get_user_profile_text(user, temperature)
 

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -156,8 +156,8 @@ def filter_clothes(
         # F-13: 계절 불일치(C=80) 제외
         if calculate_conflict_score(c, situation) >= 80:
             continue
-        # 피드백 누적 TpoScore 60 미만 옷 제외 (8회 이상 부정 피드백)
-        if tpo_scores.get(c.clothes_id, 100) < 60:
+        # 피드백 누적 TpoScore 60 이하 옷 제외 (8회 이상 부정 피드백)
+        if tpo_scores.get(c.clothes_id, 100) <= 60:
             continue
         result.append(c)
     return result

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from database import get_db
-from models import Clothes, CategoryEnum, StatusEnum, User, ThicknessEnum
+from models import Clothes, CategoryEnum, StatusEnum, User, ThicknessEnum, TpoScore
 from routers.auth import get_current_user
 from tpo_rules import get_tpo_prompt_text, check_color_conflict
 
@@ -324,6 +324,27 @@ def call_gemini(prompt: str, retries: int = 2) -> dict:
             if attempt == retries:
                 raise HTTPException(status_code=500, detail=f"AI 추천 생성 실패: {str(e)}")
 
+SITUATION_MAP = {
+    "daily": "데일리", "business": "비즈니스", "interview": "면접",
+    "wedding": "결혼식", "funeral": "장례식", "exercise": "운동",
+    "date": "데이트", "meeting": "모임", "travel": "여행",
+    "school": "데일리", "cafe": "데일리",
+}
+
+def to_situation_kr(situation: str | None) -> str:
+    if not situation:
+        return "데일리"
+    return SITUATION_MAP.get(situation, situation)
+
+def load_tpo_scores(db: Session, user_id: int, situation_kr: str) -> dict[int, int]:
+    rows = (
+        db.query(TpoScore)
+        .join(Clothes, TpoScore.clothes_id == Clothes.clothes_id)
+        .filter(Clothes.user_id == user_id, TpoScore.tpo_name == situation_kr)
+        .all()
+    )
+    return {row.clothes_id: row.score for row in rows}
+
 @router.get("/today", response_model=RecommendResponse)
 def recommend_today(
     situation: Optional[str] = None,
@@ -351,7 +372,9 @@ def recommend_today(
         raise HTTPException(status_code=500, detail=f"옷 데이터 조회 중 오류 발생: {str(e)}")
     if len(all_clothes) < 3:
         raise HTTPException(status_code=400, detail="추천을 위해 최소 3벌 이상의 옷을 등록해주세요")
-    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation or "데일리")
+    situation_kr = to_situation_kr(situation)
+    tpo_scores = load_tpo_scores(db, user_id, situation_kr)
+    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation_kr, tpo_scores)
     if len(filtered) < 2:
         return {
             "outfits": [],
@@ -387,7 +410,9 @@ def recommend_custom(
         raise HTTPException(status_code=500, detail=f"옷 데이터 조회 중 오류 발생: {str(e)}")
     if len(all_clothes) < 3:
         raise HTTPException(status_code=400, detail="추천을 위해 최소 3벌 이상의 옷을 등록해주세요")
-    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, body.situation or "데일리")
+    situation_kr = to_situation_kr(body.situation)
+    tpo_scores = load_tpo_scores(db, user_id, situation_kr)
+    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation_kr, tpo_scores)
     if len(filtered) < 2:
         return {
             "outfits": [],
@@ -421,7 +446,9 @@ def recommend_weekly(
         all_clothes = db.query(Clothes).filter(Clothes.user_id == user_id).all()
     except LookupError as e:
         raise HTTPException(status_code=500, detail=f"옷 데이터 조회 중 오류 발생: {str(e)}")
-    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation or "데일리")
+    situation_kr = to_situation_kr(situation)
+    tpo_scores = load_tpo_scores(db, user_id, situation_kr)
+    filtered, used_fallback = apply_fallback_filter(all_clothes, temperature, weather_condition, situation_kr, tpo_scores)
     if len(filtered) < 4:
         return {
             "weekly_outfits": [],

--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -455,7 +455,6 @@ def recommend_weekly(
             "tip": "주간 추천을 위해 최소 4벌 이상의 옷을 등록해주세요."
         }
     clothes_text = "\n".join([clothes_to_text(c) for c in filtered])
-    situation_kr = situation or "데일리"
 
     prompt = f"""
 당신은 패션 코디 전문가입니다.

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,6 +1,20 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
 from unittest.mock import MagicMock
 from datetime import date
+
+from database import Base, get_db
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
+
+# ──────────────────────────────────────────────
+# 기존 mock 헬퍼 (test_recommend.py, test_tpo_rules.py 단위 테스트용)
+# ──────────────────────────────────────────────
 
 def make_clothes(**kwargs):
     c = MagicMock()
@@ -32,3 +46,70 @@ def make_user(**kwargs):
     else:
         u.preferred_style = None
     return u
+
+
+# ──────────────────────────────────────────────
+# TestClient 공통 fixture (HTTP 엔드포인트 테스트용)
+# 사용법: def test_xxx(self, client, auth_headers, sample_clothes):
+# ──────────────────────────────────────────────
+
+BACKEND_DIR  = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+TEST_DB_PATH = os.path.join(BACKEND_DIR, "test_temp.db")
+TEST_DB_URL  = f"sqlite:///{TEST_DB_PATH}"
+
+
+@pytest.fixture
+def client():
+    """테스트용 DB + FastAPI 앱 클라이언트. 각 테스트 후 DB 초기화됨."""
+    from main import app
+
+    engine = create_engine(TEST_DB_URL, connect_args={"check_same_thread": False})
+    Base.metadata.create_all(bind=engine)
+    TestSession = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    def override_get_db():
+        db = TestSession()
+        try:
+            yield db
+        finally:
+            db.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    os.makedirs(os.path.join(BACKEND_DIR, "uploaded_images"), exist_ok=True)
+
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+    engine.dispose()
+    if os.path.exists(TEST_DB_PATH):
+        os.remove(TEST_DB_PATH)
+
+
+@pytest.fixture
+def auth_headers(client):
+    """테스트용 계정 가입 + 로그인 후 Authorization 헤더 반환."""
+    res = client.post("/auth/signup", json={
+        "email": "test@test.com",
+        "password": "testpass123"
+    })
+    assert res.status_code == 201, f"signup 실패: {res.json()}"
+    token = res.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture
+def sample_clothes(client, auth_headers):
+    """기본 옷 3벌 등록 후 반환 (착용기록·통계 테스트용).
+    clothes 엔드포인트가 Form 방식이므로 data= 사용."""
+    items = [
+        {"name": "흰 티셔츠", "category": "상의", "color": "화이트", "season": "사계절", "style": "캐주얼"},
+        {"name": "청바지",    "category": "하의", "color": "블루",   "season": "사계절", "style": "캐주얼"},
+        {"name": "운동화",    "category": "신발", "color": "화이트", "season": "사계절", "style": "스포티"},
+    ]
+    results = []
+    for item in items:
+        res = client.post("/clothes", headers=auth_headers, data=item)
+        results.append(res.json())
+    return results

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,24 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+class TestSignup:
+    def test_정상_가입(self, client):
+        res = client.post("/auth/signup", json={"email": "new@test.com", "password": "pass123"})
+        assert res.status_code == 201
+
+    def test_중복_이메일_거부(self, client):
+        client.post("/auth/signup", json={"email": "dup@test.com", "password": "pass123"})
+        res = client.post("/auth/signup", json={"email": "dup@test.com", "password": "pass123"})
+        assert res.status_code == 400
+
+class TestLogin:
+    def test_정상_로그인(self, client):
+        client.post("/auth/signup", json={"email": "a@test.com", "password": "pass123"})
+        res = client.post("/auth/login", json={"email": "a@test.com", "password": "pass123"})
+        assert res.status_code == 200
+        assert "access_token" in res.json()
+
+    def test_틀린_비밀번호(self, client):
+        client.post("/auth/signup", json={"email": "b@test.com", "password": "pass123"})
+        res = client.post("/auth/login", json={"email": "b@test.com", "password": "wrong"})
+        assert res.status_code == 401

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,4 +1,5 @@
-import sys, os
+import sys, os, jose.jwt
+from sqlalchemy.orm import Session
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 class TestSignup:
@@ -22,3 +23,70 @@ class TestLogin:
         client.post("/auth/signup", json={"email": "b@test.com", "password": "pass123"})
         res = client.post("/auth/login", json={"email": "b@test.com", "password": "wrong"})
         assert res.status_code == 401
+
+class TestAuthExceptions:
+    def test_잘못된_토큰_거부_JWTError(self, client):
+        # JWTError 발생 커버: 형식이 완전히 틀린 가짜 토큰 전송
+        res = client.put(
+            "/auth/me/style", 
+            headers={"Authorization": "Bearer invalid_token_string"}, 
+            json={"preferred_style": "캐주얼"}
+        )
+        assert res.status_code == 401
+
+    def test_토큰에_sub가_없는_경우(self, client, monkeypatch):
+        # user_id_from_token is None 커버: jwt.decode를 가로채서 sub가 없는 데이터를 반환하게 조작
+        monkeypatch.setattr(jose.jwt, "decode", lambda *args, **kwargs: {"other_data": "dummy"})
+        
+        res = client.put(
+            "/auth/me/style", 
+            headers={"Authorization": "Bearer dummy_token"}, 
+            json={"preferred_style": "캐주얼"}
+        )
+        assert res.status_code == 401
+
+    def test_존재하지_않는_유저_조회(self, client, monkeypatch):
+        # if user is None 커버: jwt.decode를 가로채서 DB에 절대 없는 user_id(예: 99999) 반환
+        monkeypatch.setattr(jose.jwt, "decode", lambda *args, **kwargs: {"sub": "99999"})
+        
+        res = client.put(
+            "/auth/me/style", 
+            headers={"Authorization": "Bearer dummy_token"}, 
+            json={"preferred_style": "캐주얼"}
+        )
+        assert res.status_code == 401
+
+    def test_스타일_업데이트_DB에러_500(self, client, monkeypatch):
+        # HTTP_500_INTERNAL_SERVER_ERROR 커버: DB 커밋 실패 상황
+        client.post("/auth/signup", json={"email": "error@test.com", "password": "pass123"})
+        login_res = client.post("/auth/login", json={"email": "error@test.com", "password": "pass123"})
+        token = login_res.json()["access_token"]
+        
+        def mock_commit(self):
+            raise Exception("강제 DB 에러 발생")
+        monkeypatch.setattr(Session, "commit", mock_commit)
+
+        # 스타일 업데이트 API 호출
+        res = client.put(
+            "/auth/me/style",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"preferred_style": "캐주얼"}
+        )
+
+        assert res.status_code == 500
+        assert "스타일 업데이트 중 오류가 발생했습니다" in res.json()["detail"]
+
+class TestStyleUpdate:
+    def test_정상_스타일_업데이트(self, client):
+        client.post("/auth/signup", json={"email": "style@test.com", "password": "pass123"})
+        login_res = client.post("/auth/login", json={"email": "style@test.com", "password": "pass123"})
+        token = login_res.json()["access_token"]
+        
+        res = client.put(
+            "/auth/me/style",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"preferred_style": "캐주얼"}
+        )
+        
+        assert res.status_code == 200
+        assert res.json()["preferred_style"] == "캐주얼"

--- a/backend/tests/test_clothes.py
+++ b/backend/tests/test_clothes.py
@@ -1,5 +1,6 @@
 import sys, os, io
-from unittest.mock import patch
+from unittest.mock import patch, mock_open
+from routers.clothes import get_material_tip, MATERIAL_TIPS
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 class TestClothes:
@@ -23,16 +24,35 @@ class TestClothes:
         assert res.json()["detail"] == "옷을 찾을 수 없습니다"
 
     def test_옷_등록_잘못된_이미지_확장자(self, client, auth_headers):
-        fake_file = io.BytesIO(b"fake image data")
+        data = {
+            "name": "바지", 
+            "category": "하의", 
+            "color": "블랙", 
+            "season": "사계절", 
+            "style": "캐주얼", 
+            "situation": "데일리"
+        }
+        
+        fake_file = io.BytesIO(b"fake pdf content")
         fake_file.name = "test.pdf"
         
         res = client.post(
             "/clothes",
             headers=auth_headers,
-            data={"name": "바지", "category": "하의", "color": "블랙"},
+            data=data,
             files={"image": ("test.pdf", fake_file, "application/pdf")}
         )
-        assert res.status_code in (400, 422)
+        
+        assert res.status_code == 400
+        assert res.json()["detail"] == "jpg, png, webp만 가능합니다"
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_옷_등록_이미지_업로드_성공(self, mock_file, client, auth_headers):
+        data = {"name": "이미지옷", "category": "상의", "color": "화이트", "season": "여름", "style": "캐주얼", "situation": "데일리"} 
+        files = {"image": ("test.png", b"fake image content", "image/png")}
+    
+        res = client.post("/clothes", headers=auth_headers, data=data, files=files)
+        assert res.status_code in (200, 201)
 
     def test_옷_상세_조회_성공(self, client, auth_headers, sample_clothes):
         clothes = sample_clothes[0]
@@ -45,9 +65,10 @@ class TestClothes:
         res = client.put(
             f"/clothes/{clothes['clothes_id']}",
             headers=auth_headers,
-            data={"name": "수정된 티셔츠", "category": "상의"} 
+            json={"name": "수정된 티셔츠", "category": "상의"} 
         )
-        assert res.status_code in (200, 422)
+        assert res.status_code == 200
+        assert res.json()["name"] == "수정된 티셔츠"
 
     def test_옷_상태_변경_성공(self, client, auth_headers, sample_clothes):
         clothes = sample_clothes[0]
@@ -67,30 +88,26 @@ class TestClothes:
         res_check = client.get(f"/clothes/{clothes['clothes_id']}", headers=auth_headers)
         assert res_check.status_code == 404
 
-    def test_소재_팁_조회_소재없음(self, client, auth_headers, sample_clothes):
-        clothes = sample_clothes[0]
-        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": ""})
+    def test_소재_팁_조회_소재없음(self):
+        assert get_material_tip(None) == "소재 정보가 없습니다. 옷 정보를 수정해서 소재를 입력해주세요."
+        assert get_material_tip("") == "소재 정보가 없습니다. 옷 정보를 수정해서 소재를 입력해주세요."
 
+    def test_소재_팁_조회_유사단어(self):
+        expected_tip = MATERIAL_TIPS["면"]
+        assert get_material_tip("면 100%") == expected_tip
+
+    def test_소재_팁_조회_알수없는소재(self):
+        result = get_material_tip("우주소재")
+        assert "'우주소재' 소재에 대한 팁이 아직 없습니다." in result
+
+    def test_소재_팁_조회_정확한매칭(self):
+        expected_tip = MATERIAL_TIPS["면"]
+        assert get_material_tip("면") == expected_tip
+
+    def test_소재_정보_미입력시_응답(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
         res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
         assert res.status_code == 200
-        assert "소재 정보가 없습니다" in res.json()["tip"]
-
-    def test_소재_팁_조회_유사단어(self, client, auth_headers, sample_clothes):
-        clothes = sample_clothes[0]
-        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": "면 100%"})
-        
-        res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
-        assert res.status_code == 200
-        assert "소재에 대한 팁이 아직 없습니다" not in res.json()["tip"]
-
-    def test_소재_팁_조회_알수없는소재(self, client, auth_headers, sample_clothes):
-        clothes = sample_clothes[0]
-        cid = clothes.get('clothes_id') or clothes.get('id')
-        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": "우주소재"})
-        
-        res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
-        assert res.status_code == 200
-        assert "소재 정보가 없습니다. 옷 정보를 수정해서 소재를 입력해주세요." in res.json()["tip"]
 
     # 불량 데이터 예외 처리
     @patch("routers.clothes.ClothesResponse.model_validate")

--- a/backend/tests/test_clothes.py
+++ b/backend/tests/test_clothes.py
@@ -1,10 +1,11 @@
-import sys, os
+import sys, os, io
+from unittest.mock import patch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 class TestClothes:
     def test_옷_등록(self, client, auth_headers):
         res = client.post("/clothes", headers=auth_headers,
-                          data={"name": "티셔츠", "category": "상의", "color": "블랙", "season": "사계절", "style": "캐주얼"})
+        data={"name": "티셔츠", "category": "상의", "color": "블랙", "season": "사계절", "style": "캐주얼"})
         assert res.status_code in (200, 201)
 
     def test_옷_목록_조회(self, client, auth_headers, sample_clothes):
@@ -15,3 +16,87 @@ class TestClothes:
     def test_인증없이_거부(self, client):
         res = client.get("/clothes")
         assert res.status_code in (401, 403)
+
+    def test_옷_조회_404_에러(self, client, auth_headers):
+        res = client.get("/clothes/99999", headers=auth_headers)
+        assert res.status_code == 404
+        assert res.json()["detail"] == "옷을 찾을 수 없습니다"
+
+    def test_옷_등록_잘못된_이미지_확장자(self, client, auth_headers):
+        fake_file = io.BytesIO(b"fake image data")
+        fake_file.name = "test.pdf"
+        
+        res = client.post(
+            "/clothes",
+            headers=auth_headers,
+            data={"name": "바지", "category": "하의", "color": "블랙"},
+            files={"image": ("test.pdf", fake_file, "application/pdf")}
+        )
+        assert res.status_code in (400, 422)
+
+    def test_옷_상세_조회_성공(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        res = client.get(f"/clothes/{clothes['clothes_id']}", headers=auth_headers)
+        assert res.status_code == 200
+        assert res.json()["name"] == clothes['name']
+
+    def test_옷_수정_성공(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        res = client.put(
+            f"/clothes/{clothes['clothes_id']}",
+            headers=auth_headers,
+            data={"name": "수정된 티셔츠", "category": "상의"} 
+        )
+        assert res.status_code in (200, 422)
+
+    def test_옷_상태_변경_성공(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        res = client.patch(
+            f"/clothes/{clothes['clothes_id']}/status",
+            headers=auth_headers,
+            json={"status": "세탁필요"}
+        )
+
+        assert res.status_code == 200
+        assert res.json()["status"] == "세탁필요"
+
+    def test_옷_삭제_성공(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        res = client.delete(f"/clothes/{clothes['clothes_id']}", headers=auth_headers)
+        assert res.status_code == 204
+        res_check = client.get(f"/clothes/{clothes['clothes_id']}", headers=auth_headers)
+        assert res_check.status_code == 404
+
+    def test_소재_팁_조회_소재없음(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": ""})
+
+        res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
+        assert res.status_code == 200
+        assert "소재 정보가 없습니다" in res.json()["tip"]
+
+    def test_소재_팁_조회_유사단어(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": "면 100%"})
+        
+        res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
+        assert res.status_code == 200
+        assert "소재에 대한 팁이 아직 없습니다" not in res.json()["tip"]
+
+    def test_소재_팁_조회_알수없는소재(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        cid = clothes.get('clothes_id') or clothes.get('id')
+        client.put(f"/clothes/{clothes['clothes_id']}", headers=auth_headers, data={"material": "우주소재"})
+        
+        res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
+        assert res.status_code == 200
+        assert "소재 정보가 없습니다. 옷 정보를 수정해서 소재를 입력해주세요." in res.json()["tip"]
+
+    # 불량 데이터 예외 처리
+    @patch("routers.clothes.ClothesResponse.model_validate")
+    def test_옷_목록_조회_불량데이터_무시(self, mock_validate, client, auth_headers, sample_clothes):
+        mock_validate.side_effect = Exception("고의로 발생시킨 DB 검증 에러")
+        
+        res = client.get("/clothes", headers=auth_headers)
+        assert res.status_code == 200
+        assert res.json() == []

--- a/backend/tests/test_clothes.py
+++ b/backend/tests/test_clothes.py
@@ -109,6 +109,31 @@ class TestClothes:
         res = client.get(f"/clothes/{clothes['clothes_id']}/tips", headers=auth_headers)
         assert res.status_code == 200
 
+    def test_소재_팁_API_정상_반환(self, client, auth_headers, sample_clothes):
+        clothes = sample_clothes[0]
+        
+        target_id = clothes.get("clothes_id", clothes.get("clothes_id"))
+        
+        client.put(
+            f"/clothes/{target_id}",
+            headers=auth_headers,
+            json={
+                "name": clothes["name"],
+                "category": clothes["tags"]["category"],
+                "season": clothes["tags"]["season"],
+                "style": clothes["tags"]["style"],
+                "material": "면"
+            }
+        )
+        
+        res = client.get(f"/clothes/{target_id}/tips", headers=auth_headers)
+
+        assert res.status_code == 200
+        json_data = res.json()
+        assert json_data["material"] == "면"
+        assert "clothes_name" in json_data
+        assert "tip" in json_data
+
     # 불량 데이터 예외 처리
     @patch("routers.clothes.ClothesResponse.model_validate")
     def test_옷_목록_조회_불량데이터_무시(self, mock_validate, client, auth_headers, sample_clothes):

--- a/backend/tests/test_clothes.py
+++ b/backend/tests/test_clothes.py
@@ -1,0 +1,17 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+class TestClothes:
+    def test_옷_등록(self, client, auth_headers):
+        res = client.post("/clothes", headers=auth_headers,
+                          data={"name": "티셔츠", "category": "상의", "color": "블랙", "season": "사계절", "style": "캐주얼"})
+        assert res.status_code in (200, 201)
+
+    def test_옷_목록_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/clothes", headers=auth_headers)
+        assert res.status_code == 200
+        assert isinstance(res.json(), list)
+
+    def test_인증없이_거부(self, client):
+        res = client.get("/clothes")
+        assert res.status_code in (401, 403)

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -37,3 +37,29 @@ class TestUpdateTpoScoreBad:
         rec = db.query.return_value.filter.return_value.first.return_value
         update_tpo_score(db, clothes_id=1, situation="면접", feedback_tpo=FeedbackTpoEnum.bad)
         assert rec.score == 0
+
+
+class TestUpdateTpoScoreGood:
+    def test_good_기존_점수_5회복(self):
+        db = make_db(existing_score=70)
+        rec = db.query.return_value.filter.return_value.first.return_value
+        update_tpo_score(db, clothes_id=1, situation="데일리", feedback_tpo=FeedbackTpoEnum.good)
+        assert rec.score == 75
+
+    def test_good_100_초과_클램프(self):
+        db = make_db(existing_score=98)
+        rec = db.query.return_value.filter.return_value.first.return_value
+        update_tpo_score(db, clothes_id=1, situation="데일리", feedback_tpo=FeedbackTpoEnum.good)
+        assert rec.score == 100
+
+    def test_good_레코드_없으면_추가_안함(self):
+        db = make_db(existing_score=None)
+        update_tpo_score(db, clothes_id=1, situation="데일리", feedback_tpo=FeedbackTpoEnum.good)
+        db.add.assert_not_called()
+
+    def test_normal_점수_변화_없음(self):
+        db = make_db(existing_score=80)
+        rec = db.query.return_value.filter.return_value.first.return_value
+        update_tpo_score(db, clothes_id=1, situation="데일리", feedback_tpo=FeedbackTpoEnum.normal)
+        assert rec.score == 80
+        db.add.assert_not_called()

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,0 +1,39 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from unittest.mock import MagicMock
+from models import TpoScore, FeedbackTpoEnum, FeedbackTempEnum
+from routers.feedback import update_tpo_score, update_temp_sensitivity
+
+
+def make_db(existing_score=None):
+    db = MagicMock()
+    if existing_score is not None:
+        rec = MagicMock()
+        rec.score = existing_score
+        db.query.return_value.filter.return_value.first.return_value = rec
+    else:
+        db.query.return_value.filter.return_value.first.return_value = None
+    return db
+
+
+class TestUpdateTpoScoreBad:
+    def test_bad_신규_레코드_없으면_score_95_생성(self):
+        db = make_db(existing_score=None)
+        update_tpo_score(db, clothes_id=1, situation="면접", feedback_tpo=FeedbackTpoEnum.bad)
+        db.add.assert_called_once()
+        added = db.add.call_args[0][0]
+        assert isinstance(added, TpoScore)
+        assert added.score == 95
+
+    def test_bad_기존_레코드_점수_5감소(self):
+        db = make_db(existing_score=80)
+        rec = db.query.return_value.filter.return_value.first.return_value
+        update_tpo_score(db, clothes_id=1, situation="면접", feedback_tpo=FeedbackTpoEnum.bad)
+        assert rec.score == 75
+
+    def test_bad_점수_0_미만_클램프(self):
+        db = make_db(existing_score=3)
+        rec = db.query.return_value.filter.return_value.first.return_value
+        update_tpo_score(db, clothes_id=1, situation="면접", feedback_tpo=FeedbackTpoEnum.bad)
+        assert rec.score == 0

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -63,3 +63,35 @@ class TestUpdateTpoScoreGood:
         update_tpo_score(db, clothes_id=1, situation="데일리", feedback_tpo=FeedbackTpoEnum.normal)
         assert rec.score == 80
         db.add.assert_not_called()
+
+
+class TestUpdateTempSensitivity:
+    def test_hot_민감도_감소(self):
+        user = MagicMock()
+        user.temp_sensitivity = 0.5
+        update_temp_sensitivity(user, FeedbackTempEnum.hot)
+        assert user.temp_sensitivity == 0.0
+
+    def test_cold_민감도_증가(self):
+        user = MagicMock()
+        user.temp_sensitivity = 0.5
+        update_temp_sensitivity(user, FeedbackTempEnum.cold)
+        assert user.temp_sensitivity == 1.0
+
+    def test_good_민감도_변화_없음(self):
+        user = MagicMock()
+        user.temp_sensitivity = 0.5
+        update_temp_sensitivity(user, FeedbackTempEnum.good)
+        assert user.temp_sensitivity == 0.5
+
+    def test_hot_하한_클램프(self):
+        user = MagicMock()
+        user.temp_sensitivity = -1.8
+        update_temp_sensitivity(user, FeedbackTempEnum.hot)
+        assert user.temp_sensitivity == -2.0
+
+    def test_cold_상한_클램프(self):
+        user = MagicMock()
+        user.temp_sensitivity = 1.8
+        update_temp_sensitivity(user, FeedbackTempEnum.cold)
+        assert user.temp_sensitivity == 2.0

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -2,7 +2,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text
 from unittest.mock import patch
 from datetime import date, timedelta
 
@@ -225,3 +225,27 @@ class TestToSituationKr:
 
     def test_None이면_데일리(self):
         assert to_situation_kr(None) == "데일리"
+
+
+class TestClothesToText:
+    def test_착용기록_없으면_착용기록없음_표시(self):
+        c = make_clothes(last_worn_date=None)
+        result = clothes_to_text(c)
+        assert "착용 기록 없음" in result
+
+    def test_옷_ID와_이름_포함(self):
+        c = make_clothes(clothes_id=42, name="청바지")
+        result = clothes_to_text(c)
+        assert "[ID:42]" in result
+        assert "청바지" in result
+
+    def test_situation_None이면_미입력_표시(self):
+        c = make_clothes(situation=None)
+        result = clothes_to_text(c)
+        assert "미입력" in result
+
+    def test_material_None이면_미입력_표시(self):
+        c = make_clothes()
+        c.material = None
+        result = clothes_to_text(c)
+        assert "미입력" in result

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -325,6 +325,12 @@ class TestBuildPrompt:
         assert "outfits" in prompt
         assert "items" in prompt
 
+    def test_영문_meeting이_미팅으로_변환됨(self):
+        user = make_user()
+        prompt = build_prompt([], "meeting", 20.0, "sunny", user)
+        assert "미팅" in prompt
+        assert "모임" not in prompt
+
 
 class TestLoadTpoScores:
     def _make_db(self, rows):
@@ -537,3 +543,14 @@ class TestRecommendEndpoints:
                               json={"situation": "daily", "temperature": 20.0, "weather_condition": "sunny"})
         assert res.status_code == 200
         assert res.json()["outfits"] == []
+
+    def test_weekly_인증없이_거부(self, client):
+        res = client.get("/recommend/weekly")
+        assert res.status_code in (401, 403)
+
+    def test_weekly_filtered_부족_empty반환(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.apply_fallback_filter", return_value=([], False)):
+            res = client.get("/recommend/weekly", headers=auth_headers,
+                             params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+        assert res.json()["weekly_outfits"] == []

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -2,7 +2,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr
 from unittest.mock import patch
 from datetime import date, timedelta
 
@@ -189,3 +189,35 @@ class TestApplyFallbackFilter:
         with patch("routers.recommend.get_current_season", return_value="봄"):
             result, used = apply_fallback_filter([top_spring, top_winter_washing] + bottoms, 20.0, "sunny")
         assert top_winter_washing not in result
+
+
+class TestFilterClothesTpoScore:
+    def test_tpo_score_60미만_제외(self):
+        c = make_clothes(clothes_id=1)
+        assert filter_clothes([c], 20.0, "sunny", tpo_scores={1: 59}) == []
+
+    def test_tpo_score_60이상_포함(self):
+        c = make_clothes(clothes_id=1)
+        assert c in filter_clothes([c], 20.0, "sunny", tpo_scores={1: 60})
+
+    def test_tpo_score_없으면_기본값100_포함(self):
+        c = make_clothes(clothes_id=1)
+        assert c in filter_clothes([c], 20.0, "sunny", tpo_scores={})
+
+    def test_tpo_scores_None이면_모두포함(self):
+        c = make_clothes(clothes_id=1)
+        assert c in filter_clothes([c], 20.0, "sunny", tpo_scores=None)
+
+
+class TestToSituationKr:
+    def test_영문_daily_데일리(self):
+        assert to_situation_kr("daily") == "데일리"
+
+    def test_영문_interview_면접(self):
+        assert to_situation_kr("interview") == "면접"
+
+    def test_한글_그대로반환(self):
+        assert to_situation_kr("데일리") == "데일리"
+
+    def test_None이면_데일리(self):
+        assert to_situation_kr(None) == "데일리"

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -2,7 +2,7 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt
 from unittest.mock import patch
 from datetime import date, timedelta
 
@@ -249,3 +249,34 @@ class TestClothesToText:
         c.material = None
         result = clothes_to_text(c)
         assert "미입력" in result
+
+
+class TestBuildPrompt:
+    def _make_top(self, clothes_id=1):
+        c = make_clothes(clothes_id=clothes_id, category=CategoryEnum.top)
+        c.category = CategoryEnum.top
+        return c
+
+    def _make_bottom(self, clothes_id=2):
+        c = make_clothes(clothes_id=clothes_id, category=CategoryEnum.bottom)
+        c.category = CategoryEnum.bottom
+        return c
+
+    def test_영문_상황이_한국어로_변환됨(self):
+        user = make_user()
+        prompt = build_prompt([], "interview", 20.0, "sunny", user)
+        assert "면접" in prompt
+
+    def test_옷_ID가_프롬프트에_포함됨(self):
+        user = make_user()
+        top = self._make_top(clothes_id=99)
+        bottom = self._make_bottom(clothes_id=88)
+        prompt = build_prompt([top, bottom], "daily", 20.0, "sunny", user)
+        assert "ID:99" in prompt
+        assert "ID:88" in prompt
+
+    def test_JSON_응답형식_포함됨(self):
+        user = make_user()
+        prompt = build_prompt([], "daily", 20.0, "sunny", user)
+        assert "outfits" in prompt
+        assert "items" in prompt

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -196,9 +196,13 @@ class TestFilterClothesTpoScore:
         c = make_clothes(clothes_id=1)
         assert filter_clothes([c], 20.0, "sunny", tpo_scores={1: 59}) == []
 
-    def test_tpo_score_60이상_포함(self):
+    def test_tpo_score_정확히60_제외(self):
         c = make_clothes(clothes_id=1)
-        assert c in filter_clothes([c], 20.0, "sunny", tpo_scores={1: 60})
+        assert filter_clothes([c], 20.0, "sunny", tpo_scores={1: 60}) == []
+
+    def test_tpo_score_61이상_포함(self):
+        c = make_clothes(clothes_id=1)
+        assert c in filter_clothes([c], 20.0, "sunny", tpo_scores={1: 61})
 
     def test_tpo_score_없으면_기본값100_포함(self):
         c = make_clothes(clothes_id=1)

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -47,6 +47,10 @@ class TestFilterClothes:
         )
         assert c in filter_clothes([c], 20.0, "sunny")
 
+    def test_세탁필요_제외(self):
+        c = make_clothes(status=StatusEnum.need_wash)
+        assert filter_clothes([c], 20.0, "sunny") == []
+
     def test_빈리스트(self):
         assert filter_clothes([], 20.0, "sunny") == []
 
@@ -114,6 +118,11 @@ class TestGetCurrentSeason:
             mock_date.today.return_value = date(2026, 7, 1)
             assert get_current_season() == "여름"
 
+    def test_9월_가을(self):
+        with patch("routers.recommend.date") as mock_date:
+            mock_date.today.return_value = date(2026, 9, 1)
+            assert get_current_season() == "가을"
+
     def test_12월_겨울(self):
         with patch("routers.recommend.date") as mock_date:
             mock_date.today.return_value = date(2026, 12, 1)
@@ -144,6 +153,11 @@ class TestCalculateConflictScore:
         c = make_clothes(season="봄", color="블랙")
         with patch("routers.recommend.get_current_season", return_value="봄"):
             assert calculate_conflict_score(c, "면접") == 0
+
+    def test_영문_interview도_면접_60반환(self):
+        c = make_clothes(season="봄", color="레드")
+        with patch("routers.recommend.get_current_season", return_value="봄"):
+            assert calculate_conflict_score(c, "interview") == 60
 
 
 class TestFilterClothesF13:

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -454,8 +454,45 @@ class TestRecommendEndpoints:
 
     def test_weekly_정상_추천(self, client, auth_headers, sample_clothes):
         client.post("/clothes", headers=auth_headers,
-                    json={"name": "후드티", "category": "상의", "season": "사계절", "status": "착용가능"})
+                    data={"name": "후드티", "category": "상의", "color": "그레이", "season": "사계절", "style": "캐주얼"})
         with patch("routers.recommend.call_gemini", return_value=self.GEMINI_WEEKLY_OK):
             res = client.get("/recommend/weekly", headers=auth_headers,
                              params={"temperature": 20.0, "weather_condition": "sunny"})
         assert res.status_code == 200
+
+    def test_today_address_날씨조회(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.fetch_weather", return_value={"temperature": 18.0, "condition": "cloudy"}):
+            with patch("routers.recommend.call_gemini", return_value=self.GEMINI_OK):
+                res = client.get("/recommend/today", headers=auth_headers,
+                                 params={"address": "서울"})
+        assert res.status_code == 200
+
+    def test_custom_address_날씨조회(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.fetch_weather", return_value={"temperature": 18.0, "condition": "cloudy"}):
+            with patch("routers.recommend.call_gemini", return_value=self.GEMINI_OK):
+                res = client.post("/recommend/custom", headers=auth_headers,
+                                  json={"situation": "daily", "address": "서울"})
+        assert res.status_code == 200
+
+    def test_weekly_address_날씨조회(self, client, auth_headers, sample_clothes):
+        client.post("/clothes", headers=auth_headers,
+                    data={"name": "후드티", "category": "상의", "color": "그레이", "season": "사계절", "style": "캐주얼"})
+        with patch("routers.recommend.fetch_weather", return_value={"temperature": 18.0, "condition": "cloudy"}):
+            with patch("routers.recommend.call_gemini", return_value=self.GEMINI_WEEKLY_OK):
+                res = client.get("/recommend/weekly", headers=auth_headers,
+                                 params={"address": "서울"})
+        assert res.status_code == 200
+
+    def test_today_filtered_부족_empty반환(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.apply_fallback_filter", return_value=([], False)):
+            res = client.get("/recommend/today", headers=auth_headers,
+                             params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+        assert res.json()["outfits"] == []
+
+    def test_custom_filtered_부족_empty반환(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.apply_fallback_filter", return_value=([], False)):
+            res = client.post("/recommend/custom", headers=auth_headers,
+                              json={"situation": "daily", "temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+        assert res.json()["outfits"] == []

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -223,6 +223,33 @@ class TestToSituationKr:
     def test_영문_interview_면접(self):
         assert to_situation_kr("interview") == "면접"
 
+    def test_영문_meeting_미팅(self):
+        assert to_situation_kr("meeting") == "미팅"
+
+    def test_영문_business_비즈니스(self):
+        assert to_situation_kr("business") == "비즈니스"
+
+    def test_영문_wedding_결혼식(self):
+        assert to_situation_kr("wedding") == "결혼식"
+
+    def test_영문_funeral_장례식(self):
+        assert to_situation_kr("funeral") == "장례식"
+
+    def test_영문_exercise_운동(self):
+        assert to_situation_kr("exercise") == "운동"
+
+    def test_영문_date_데이트(self):
+        assert to_situation_kr("date") == "데이트"
+
+    def test_영문_travel_여행(self):
+        assert to_situation_kr("travel") == "여행"
+
+    def test_영문_school_데일리폴백(self):
+        assert to_situation_kr("school") == "데일리"
+
+    def test_영문_cafe_데일리폴백(self):
+        assert to_situation_kr("cafe") == "데일리"
+
     def test_한글_그대로반환(self):
         assert to_situation_kr("데일리") == "데일리"
 

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -1,5 +1,6 @@
 import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, os.path.dirname(__file__))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
 from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt, load_tpo_scores

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -2,8 +2,8 @@ import sys, os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt
-from unittest.mock import patch
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt, load_tpo_scores
+from unittest.mock import patch, MagicMock
 from datetime import date, timedelta
 
 class TestFilterClothes:
@@ -280,3 +280,28 @@ class TestBuildPrompt:
         prompt = build_prompt([], "daily", 20.0, "sunny", user)
         assert "outfits" in prompt
         assert "items" in prompt
+
+
+class TestLoadTpoScores:
+    def _make_db(self, rows):
+        db = MagicMock()
+        db.query.return_value.join.return_value.filter.return_value.all.return_value = rows
+        return db
+
+    def test_점수_딕셔너리로_반환(self):
+        row1 = MagicMock(clothes_id=1, score=80)
+        row2 = MagicMock(clothes_id=2, score=65)
+        db = self._make_db([row1, row2])
+        result = load_tpo_scores(db, user_id=1, situation_kr="면접")
+        assert result == {1: 80, 2: 65}
+
+    def test_결과_없으면_빈_딕셔너리(self):
+        db = self._make_db([])
+        result = load_tpo_scores(db, user_id=1, situation_kr="데일리")
+        assert result == {}
+
+    def test_단일_레코드_반환(self):
+        row = MagicMock(clothes_id=5, score=95)
+        db = self._make_db([row])
+        result = load_tpo_scores(db, user_id=1, situation_kr="미팅")
+        assert result[5] == 95

--- a/backend/tests/test_recommend.py
+++ b/backend/tests/test_recommend.py
@@ -3,9 +3,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 sys.path.insert(0, os.path.dirname(__file__))
 from conftest import make_clothes, make_user
 from models import StatusEnum, CategoryEnum, ThicknessEnum, MaterialEnum
-from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt, load_tpo_scores
+from routers.recommend import filter_clothes, apply_fallback_filter, get_unworn_days, get_user_profile_text, get_current_season, calculate_conflict_score, to_situation_kr, clothes_to_text, build_prompt, load_tpo_scores, fetch_weather, call_gemini
 from unittest.mock import patch, MagicMock
 from datetime import date, timedelta
+import pytest
+from fastapi import HTTPException
 
 class TestFilterClothes:
     def test_세탁중_제외(self):
@@ -306,3 +308,154 @@ class TestLoadTpoScores:
         db = self._make_db([row])
         result = load_tpo_scores(db, user_id=1, situation_kr="미팅")
         assert result[5] == 95
+
+
+class TestFetchWeather:
+    def _mock_httpx(self, mock_client, return_value):
+        mock_client.return_value.__enter__.return_value.get.return_value = return_value
+
+    def test_비오는날_rainy(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "success",
+            "weather": {"현재 기온": "15°C", "하늘 상태": "흐림", "강수 형태": "비"}
+        }
+        with patch("routers.recommend.httpx.Client") as mc:
+            self._mock_httpx(mc, mock_resp)
+            result = fetch_weather("서울")
+        assert result["condition"] == "rainy"
+        assert result["temperature"] == 15.0
+
+    def test_눈오는날_snowy(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "success",
+            "weather": {"현재 기온": "0°C", "하늘 상태": "흐림", "강수 형태": "눈"}
+        }
+        with patch("routers.recommend.httpx.Client") as mc:
+            self._mock_httpx(mc, mock_resp)
+            result = fetch_weather("서울")
+        assert result["condition"] == "snowy"
+
+    def test_맑은날_sunny(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "success",
+            "weather": {"현재 기온": "25°C", "하늘 상태": "맑음", "강수 형태": "없음"}
+        }
+        with patch("routers.recommend.httpx.Client") as mc:
+            self._mock_httpx(mc, mock_resp)
+            result = fetch_weather("서울")
+        assert result["condition"] == "sunny"
+
+    def test_흐린날_cloudy(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "status": "success",
+            "weather": {"현재 기온": "18°C", "하늘 상태": "구름많음", "강수 형태": "없음"}
+        }
+        with patch("routers.recommend.httpx.Client") as mc:
+            self._mock_httpx(mc, mock_resp)
+            result = fetch_weather("서울")
+        assert result["condition"] == "cloudy"
+
+    def test_status_실패시_기본값반환(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"status": "error"}
+        with patch("routers.recommend.httpx.Client") as mc:
+            self._mock_httpx(mc, mock_resp)
+            result = fetch_weather("서울")
+        assert result == {"temperature": 20.0, "condition": "sunny"}
+
+    def test_예외발생시_기본값반환(self):
+        with patch("routers.recommend.httpx.Client") as mc:
+            mc.return_value.__enter__.return_value.get.side_effect = Exception("연결 실패")
+            result = fetch_weather("서울")
+        assert result == {"temperature": 20.0, "condition": "sunny"}
+
+
+class TestCallGemini:
+    def test_정상_JSON_반환(self):
+        mock_resp = MagicMock()
+        mock_resp.text = '{"outfits": [{"outfit_number": 1, "items": [{"clothes_id": 1, "name": "티", "category": "상의", "color": "블랙"}], "reason": "좋아"}], "ai_message": "추천"}'
+        with patch("routers.recommend.model.generate_content", return_value=mock_resp):
+            result = call_gemini("test prompt")
+        assert "outfits" in result
+        assert len(result["outfits"]) == 1
+
+    def test_백틱_JSON_파싱(self):
+        mock_resp = MagicMock()
+        mock_resp.text = '```json\n{"outfits": [{"outfit_number": 1, "items": [], "reason": "좋아"}], "ai_message": "추천"}\n```'
+        with patch("routers.recommend.model.generate_content", return_value=mock_resp):
+            result = call_gemini("test prompt")
+        assert "outfits" in result
+
+    def test_outfits_없으면_HTTPException(self):
+        mock_resp = MagicMock()
+        mock_resp.text = '{"outfits": [], "ai_message": "없음"}'
+        with patch("routers.recommend.model.generate_content", return_value=mock_resp):
+            with pytest.raises(HTTPException) as exc:
+                call_gemini("test prompt", retries=0)
+        assert exc.value.status_code == 500
+
+
+class TestRecommendEndpoints:
+    GEMINI_OK = {
+        "outfits": [{
+            "outfit_number": 1,
+            "items": [{"clothes_id": 1, "name": "티셔츠", "category": "상의", "color": "블랙"}],
+            "reason": "좋은 코디입니다"
+        }],
+        "ai_message": "오늘의 추천 완료"
+    }
+    GEMINI_WEEKLY_OK = {
+        "weekly_outfits": [
+            {"day": "월요일", "items": [{"clothes_id": 1, "name": "티셔츠", "category": "상의", "color": "블랙"}], "reason": "좋아"},
+            {"day": "화요일", "items": [], "reason": "좋아"},
+            {"day": "수요일", "items": [], "reason": "좋아"},
+            {"day": "목요일", "items": [], "reason": "좋아"},
+            {"day": "금요일", "items": [], "reason": "좋아"},
+        ],
+        "tip": "이번 주 팁"
+    }
+
+    def test_today_인증없이_거부(self, client):
+        res = client.get("/recommend/today")
+        assert res.status_code in (401, 403)
+
+    def test_today_옷부족_400(self, client, auth_headers):
+        res = client.get("/recommend/today", headers=auth_headers,
+                         params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 400
+
+    def test_today_정상_추천(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.call_gemini", return_value=self.GEMINI_OK):
+            res = client.get("/recommend/today", headers=auth_headers,
+                             params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+        assert "outfits" in res.json()
+
+    def test_custom_옷부족_400(self, client, auth_headers):
+        res = client.post("/recommend/custom", headers=auth_headers,
+                          json={"situation": "daily", "temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 400
+
+    def test_custom_정상_추천(self, client, auth_headers, sample_clothes):
+        with patch("routers.recommend.call_gemini", return_value=self.GEMINI_OK):
+            res = client.post("/recommend/custom", headers=auth_headers,
+                              json={"situation": "daily", "temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+
+    def test_weekly_옷부족_empty반환(self, client, auth_headers, sample_clothes):
+        res = client.get("/recommend/weekly", headers=auth_headers,
+                         params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200
+        assert res.json()["weekly_outfits"] == []
+
+    def test_weekly_정상_추천(self, client, auth_headers, sample_clothes):
+        client.post("/clothes", headers=auth_headers,
+                    json={"name": "후드티", "category": "상의", "season": "사계절", "status": "착용가능"})
+        with patch("routers.recommend.call_gemini", return_value=self.GEMINI_WEEKLY_OK):
+            res = client.get("/recommend/weekly", headers=auth_headers,
+                             params={"temperature": 20.0, "weather_condition": "sunny"})
+        assert res.status_code == 200

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -1,7 +1,56 @@
 import pytest
 from datetime import datetime
 from unittest.mock import patch
-from utils import get_base_time 
+from utils import get_base_time, get_coords_from_address, convert_grid
+
+@patch('utils.requests.get')
+def test_get_coords_from_address_success(mock_get):
+    """정상적으로 위경도 데이터를 받아오는 경우"""
+    mock_get.return_value.json.return_value = [{'lat': '37.5665', 'lon': '126.9780'}]
+    lat, lon = get_coords_from_address("서울")
+    
+    assert lat == 37.5665
+    assert lon == 126.9780
+
+@patch('utils.requests.get')
+def test_get_coords_from_address_no_data(mock_get):
+    """검색 결과가 빈 배열([])로 반환되는 경우 (if data: 분기 통과 못함)"""
+    mock_get.return_value.json.return_value = []
+    lat, lon = get_coords_from_address("이상한주소")
+    
+    assert lat is None
+    assert lon is None
+
+@patch('utils.requests.get')
+def test_get_coords_from_address_exception(mock_get):
+    """API 호출 중 타임아웃 등 예외(Exception)가 발생하는 경우"""
+    mock_get.side_effect = Exception("API Error")
+    lat, lon = get_coords_from_address("서울")
+    
+    assert lat is None
+    assert lon is None
+
+def test_convert_grid_normal():
+    """일반적인 위경도(예: 서울) 입력 시 정상 격자 반환 검증"""
+    nx, ny = convert_grid(37.5665, 126.9780)
+    
+    assert isinstance(nx, int)
+    assert isinstance(ny, int)
+    assert nx == 60  # 서울시청 부근 기상청 X 격자
+    assert ny == 127 # 서울시청 부근 기상청 Y 격자
+
+def test_convert_grid_edge_cases():
+    """
+    기상청 격자 변환 로직 내의 방위각(theta) 예외 분기 커버
+    if theta > math.pi / if theta < -math.pi 로직을 밟도록 고의적으로 극단적 경도 입력
+    """
+    # theta > math.pi 조건을 충족하는 경도 입력
+    nx1, ny1 = convert_grid(37.0, 310.0)
+    assert isinstance(nx1, int)
+    
+    # theta < -math.pi 조건을 충족하는 경도 입력
+    nx2, ny2 = convert_grid(37.0, -60.0)
+    assert isinstance(nx2, int)
 
 def test_get_base_time_midnight_edge_case():
     """
@@ -12,7 +61,6 @@ def test_get_base_time_midnight_edge_case():
     
     with patch('utils.datetime') as mock_datetime:
         mock_datetime.now.return_value = mock_now
-        
         base_date, base_time = get_base_time()
         
         assert base_date == "20260519"  # 전날 날짜로 정상 계산되는지 검증
@@ -44,7 +92,6 @@ def test_get_base_time_normal_daytime():
     
     with patch('utils.datetime') as mock_datetime:
         mock_datetime.now.return_value = mock_now
-        
         base_date, base_time = get_base_time()
         
         assert base_date == "20260520"  # 당일 날짜 유지

--- a/backend/tests/test_weather.py
+++ b/backend/tests/test_weather.py
@@ -1,0 +1,126 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from unittest.mock import patch, MagicMock
+import importlib
+import sys
+import os
+from io import StringIO
+
+from routers import weather
+from routers.weather import router
+
+app = FastAPI()
+app.include_router(router)
+client = TestClient(app)
+
+class TestWeatherAPI:
+    @patch("routers.weather.requests.get")
+    @patch("routers.weather.get_base_time")
+    @patch("routers.weather.convert_grid")
+    @patch("routers.weather.get_coords_from_address")
+    def test_날씨_조회_성공_모든_조건_통과(self, mock_coords, mock_grid, mock_time, mock_requests):
+        """정상적인 API 응답 및 모든 if/elif 카테고리(TMP, TMX, TMN, SKY, PTY, POP) 파싱 검증"""
+        mock_coords.return_value = (37.5665, 126.9780)
+        mock_grid.return_value = (60, 127)
+        mock_time.return_value = ("20260529", "1400")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "response": {
+                "header": {"resultCode": "00"},
+                "body": {
+                    "items": {
+                        "item": [
+                            {"category": "TMP", "fcstValue": "25"},
+                            {"category": "TMX", "fcstValue": "30"},
+                            {"category": "TMN", "fcstValue": "20"},
+                            {"category": "SKY", "fcstValue": "3"},
+                            {"category": "PTY", "fcstValue": "1"},
+                            {"category": "POP", "fcstValue": "80"},
+                            {"category": "WSD", "fcstValue": "5"}
+                        ]
+                    }
+                }
+            }
+        }
+        mock_requests.return_value = mock_response
+
+        response = client.get("/weather/address?address=서울시")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert data["base_info"]["date"] == "2026-05-29"
+        assert data["base_info"]["time"] == "14시 00분"
+        
+        weather_data = data["weather"]
+        assert weather_data["현재 기온"] == "25°C"
+        assert weather_data["최고 기온"] == "30°C"
+        assert weather_data["최저 기온"] == "20°C"
+        assert weather_data["하늘 상태"] == "구름많음"
+        assert weather_data["강수 형태"] == "비"
+        assert weather_data["강수 확률"] == "80%"
+
+    @patch("routers.weather.get_coords_from_address")
+    def test_유효하지_않은_주소(self, mock_coords):
+        """주소 변환 실패(lat is None) 시 400 에러 검증"""
+        mock_coords.return_value = (None, None)
+
+        response = client.get("/weather/address?address=알수없는곳")
+        
+        assert response.status_code == 400
+        assert response.json()["detail"] == "유효하지 않은 주소입니다."
+
+    @patch("routers.weather.requests.get")
+    @patch("routers.weather.get_base_time")
+    @patch("routers.weather.convert_grid")
+    @patch("routers.weather.get_coords_from_address")
+    def test_기상청_API_응답_오류(self, mock_coords, mock_grid, mock_time, mock_requests):
+        """기상청 서버에서 resultCode가 '00'이 아닌 에러 코드를 내려줄 때 검증"""
+        mock_coords.return_value = (37.5665, 126.9780)
+        mock_grid.return_value = (60, 127)
+        mock_time.return_value = ("20260529", "1400")
+
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "response": {
+                "header": {"resultCode": "10", "resultMsg": "오류 발생"}
+            }
+        }
+        mock_requests.return_value = mock_response
+
+        response = client.get("/weather/address?address=서울시")
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "error"
+        assert data["message"] == "기상청 API 응답 오류"
+
+    @patch("routers.weather.requests.get")
+    @patch("routers.weather.get_coords_from_address")
+    def test_통신_예외_발생(self, mock_coords, mock_requests):
+        """requests.get에서 타임아웃 등 Exception이 터졌을 때 500 에러 검증"""
+        mock_coords.return_value = (37.5665, 126.9780)
+        
+        mock_requests.side_effect = Exception("Timeout Error")
+
+        response = client.get("/weather/address?address=서울시")
+        
+        assert response.status_code == 500
+        assert "Timeout Error" in response.json()["detail"]
+
+    def test_환경변수_누락_프린트문_커버리지(self):
+        """
+        파일 최상단의 `if not SERVICE_KEY: print(...)` 라인을 커버하기 위한 테스트.
+        모듈을 강제로 리로드하여 확인합니다.
+        """
+        with patch.dict(os.environ, {}, clear=True):
+            captured_output = StringIO()
+            sys.stdout = captured_output
+
+            importlib.reload(weather)
+
+            sys.stdout = sys.__stdout__
+
+            assert "WEATHER_SERVICE_KEY 환경 변수가 로드되지 않았습니다." in captured_output.getvalue()


### PR DESCRIPTION
## 개요
착용 피드백(feedback_tpo)으로 누적된 TpoScore를 추천 필터에 반영합니다.
부정 피드백이 8회 이상 누적된 옷(60점 미만)은 해당 상황 추천에서 제외됩니다.

## 변경 사항
- `filter_clothes`: tpo_scores 파라미터 추가, 60점 미만 옷 제외
- `load_tpo_scores`: 사용자·상황별 TpoScore 조회 헬퍼 추가
- `to_situation_kr`: 영/한 상황명 변환 헬퍼 추가
- `/recommend/today`, `/recommend/custom`, `/recommend/weekly` 3개 엔드포인트 연동
- weekly 엔드포인트 situation_kr 중복 정의 버그 수정

## 테스트
- TpoScore 필터 케이스 4개, to_situation_kr 케이스 4개 추가
- 기존 포함 총 42개 테스트 전체 통과

## 추가 작업: UnitTest Coverage 80% 달성

**공통 테스트 인프라:**
- conftest.py에 TestClient 공통 fixture 추가 (client, auth_headers, sample_clothes)
- 팀 전체 테스트에서 재사용 가능

**신규 테스트 클래스:**
- TestClothesToText, TestBuildPrompt, TestLoadTpoScores
- TestFetchWeather (6케이스), TestCallGemini (3케이스)
- TestRecommendEndpoints (12케이스) — /today, /custom, /weekly 통합 테스트
- TestApplyFallbackFilter
- test_auth.py, test_clothes.py (B파트 협업)

**Coverage 결과:**
- TOTAL: 85% (61% → 85%)
- routers/recommend.py: 98%
- 실행 명령어: `python -m pytest tests/ --cov=. --cov-report=term-missing`