### PR TITLE
[Feature] 옷장 진단(analysis) 탭 네비게이션 구조 신설 및 AI 분석 의류 그리드 UI 구현

### DIFF
--- a/ClosetApp/app/(tabs)/_layout.tsx
+++ b/ClosetApp/app/(tabs)/_layout.tsx
@@ -43,6 +43,16 @@ export default function TabLayout() {
           ),
         }}
       />
+
+      <Tabs.Screen
+        name="analysis"
+        options={{
+          title: '진단',
+          tabBarIcon: ({ color, size }) => (
+            <Ionicons name="analytics" size={size} color={color} />
+          ),
+        }}
+      />
     </Tabs>
   );
 }

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -1,31 +1,54 @@
 import { Ionicons } from '@expo/vector-icons';
-import { useFocusEffect } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import {
     ActivityIndicator,
+    Image,
     ScrollView,
     StyleSheet,
     Text,
-    View
+    TouchableOpacity,
+    View,
 } from 'react-native';
 import api from '../_api';
 
+// 백엔드 의류 데이터 규격 정의
+type BackendClothesItem = {
+  clothes_id: number;
+  category: string;
+  color: string;
+  season: string;
+  material: string;
+  price: number;
+  wear_count: number;
+  image?: string;
+};
+
+type OverloadGroup = {
+  category: string;
+  color: string;
+  count: number;
+  warning_message: string;
+  items: BackendClothesItem[];
+};
+
 export default function AnalysisScreen() {
+  const router = useRouter();
   const [loading, setLoading] = useState(false);
 
-  // 🚨 옷장 분석용 상태 관리 변수들 (과부하 배너 및 처분 제안 스토어)
+  // 🚨 옷장 분석 데이터 저장용 상태 관리 스태이트
   const [overloadData, setOverloadData] = useState<{
     total_warnings: number;
     ai_advice: string;
-    items: any[];
+    items: OverloadGroup[];
   } | null>(null);
 
   const [disposalData, setDisposalData] = useState<{
-    items: any[];
+    items: BackendClothesItem[];
     ai_advice: string;
   } | null>(null);
 
-  // ✅ 화면이 열리거나 탭이 포커스될 때마다 실시간으로 백엔드 통계 데이터 갱신
+  // ✅ 진단 탭을 누를 때마다 백엔드 서버의 통계 데이터를 최신 상태로 원격 동기화
   useFocusEffect(
     useCallback(() => {
       let isMounted = true;
@@ -33,7 +56,6 @@ export default function AnalysisScreen() {
         if (!isMounted) return;
         setLoading(true);
         try {
-          // 1. 과부하 및 2. 처분 추천 API 동시 병렬 요청
           const [overloadRes, disposalRes] = await Promise.all([
             api.get('/stats/overload'),
             api.get('/stats/dispose', { params: { current_season: '여름' } }),
@@ -57,6 +79,39 @@ export default function AnalysisScreen() {
     }, [])
   );
 
+  // 공통 의류 카드 컴포넌트 렌더러 (백엔드 플랫 데이터 매핑)
+  const renderClothesCard = (item: BackendClothesItem, badgeType?: 'overload' | 'dispose') => {
+    // 혹시 백엔드에서 이미지 스트링이 누락되었을 때 터지지 않게 기본 더미 이미지 처리
+    const imageUri = item.image || 'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?q=80&w=300&auto=format&fit=crop';
+    
+    return (
+      <TouchableOpacity
+        key={item.clothes_id}
+        style={styles.card}
+        activeOpacity={0.9}
+        onPress={() => router.push({ pathname: '/detail', params: { id: item.clothes_id.toString() } })}
+      >
+        <View style={styles.cardImageWrap}>
+          <Image source={{ uri: imageUri }} style={styles.cardImage} resizeMode="contain" />
+          {badgeType === 'overload' && (
+            <View style={[styles.cardBadge, styles.overloadBadge]}><Text style={styles.cardBadgeText}>중복</Text></View>
+          )}
+          {badgeType === 'dispose' && (
+            <View style={[styles.cardBadge, styles.disposeBadge]}><Text style={styles.cardBadgeText}>방치됨</Text></View>
+          )}
+        </View>
+        <View style={styles.cardBody}>
+          <Text style={styles.cardTitle} numberOfLines={1}>{item.category}</Text>
+          <View style={styles.cardTagRow}>
+            <Text style={styles.cardTag}>{item.color}</Text>
+            <Text style={styles.cardTag}>{item.material || '기본'}</Text>
+            <Text style={[styles.cardTag, styles.countTag]}>{item.wear_count}회 착용</Text>
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
   if (loading && !overloadData && !disposalData) {
     return (
       <View style={styles.loadingContainer}>
@@ -65,16 +120,22 @@ export default function AnalysisScreen() {
     );
   }
 
+  // 총 몇 개의 주의 아이템 카드가 바인딩되어야 하는지 계산
+  const totalOverloadCount = overloadData?.items?.reduce((acc, cur) => acc + (cur.items?.length || 0), 0) || 0;
+  const totalDisposeCount = disposalData?.items?.length || 0;
+  const hasAnyItems = totalOverloadCount > 0 || totalDisposeCount > 0;
+
   return (
     <View style={styles.container}>
       <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
-        {/* 상단 텍스트 영역 */}
+        
+        {/* 대제목 헤더 */}
         <View style={styles.headerRow}>
           <Text style={styles.title}>옷장 진단</Text>
           <Text style={styles.subtitle}>AI가 내 옷장을 분석하여 스마트한 다이어트를 도와줍니다.</Text>
         </View>
 
-        {/* 1. 과부하 분석 배너 영역 (Red Theme) */}
+        {/* 1. 과부하 분석 배너 영역 */}
         {overloadData && overloadData.total_warnings > 0 ? (
           <View style={styles.overloadBannerBox}>
             <View style={styles.overloadBannerHeader}>
@@ -93,7 +154,7 @@ export default function AnalysisScreen() {
           </View>
         )}
 
-        {/* 2. 장기 미착용 의류 처분 제안 배너 영역 (Amber Theme) */}
+        {/* 2. 장기 미착용 의류 처분 제안 배너 영역 */}
         {disposalData && disposalData.items?.length > 0 ? (
           <View style={styles.disposalBannerBox}>
             <View style={styles.disposalBannerHeader}>
@@ -112,14 +173,30 @@ export default function AnalysisScreen() {
           </View>
         )}
 
-        {/* 향후 Step 3에서 채워넣을 데이터 그리드 영역 미리 확보 */}
+        {/* 3. 주의 필요한 아이템 리스트 실시간 그리드 바인딩 */}
         <View style={styles.resultHeader}>
-          <Text style={styles.resultTitle}>주의 필요한 아이템 상세 내역</Text>
+          <Text style={styles.resultTitle}>진단 대상 의류 상세 내역</Text>
+          <Text style={styles.resultCount}>총 {totalOverloadCount + totalDisposeCount}개</Text>
         </View>
-        <View style={styles.emptyGridPlaceholder}>
-          <Ionicons name="layers-outline" size={40} color="#9ca3af" />
-          <Text style={styles.placeholderText}>다음 단계에서 개별 의류 리스트 카드가 이곳에 정렬됩니다.</Text>
-        </View>
+
+        {!hasAnyItems ? (
+          <View style={styles.emptyGridPlaceholder}>
+            <Ionicons name="sparkles-outline" size={40} color="#16a34a" />
+            <Text style={styles.placeholderText}>옷장이 아주 깨끗하고 이상적으로 관리되고 있습니다!</Text>
+          </View>
+        ) : (
+          <View style={styles.grid}>
+            {/* 과부하 중복 옷 무더기들 바인딩 */}
+            {overloadData?.items?.map((group) => 
+              group.items?.map((item) => renderClothesCard(item, 'overload'))
+            )}
+
+            {/* 90일 이상 안 입은 처분 대상 옷들 바인딩 */}
+            {disposalData?.items?.map((item) => 
+              renderClothesCard(item, 'dispose')
+            )}
+          </View>
+        )}
       </ScrollView>
     </View>
   );
@@ -159,24 +236,42 @@ const styles = StyleSheet.create({
   disposalBannerTitle: { fontSize: 14, fontWeight: '800', color: '#d97706' },
   disposalBannerText: { fontSize: 14, color: '#4b5563', lineHeight: 22, fontWeight: '600' },
   
-  // 안전 및 정보 알림 서브 스타일
+  // 안전 상태 안내 공통
   safeBannerBox: { backgroundColor: '#f9fafb', borderColor: '#f3f4f6' },
   safeBannerTitle: { color: '#16a34a' },
   infoBannerTitle: { color: '#2563eb' },
 
-  resultHeader: { marginTop: 10, marginBottom: 12, paddingHorizontal: 2 },
+  resultHeader: { marginTop: 10, marginBottom: 14, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', paddingHorizontal: 2 },
   resultTitle: { fontSize: 17, fontWeight: '800', color: '#111' },
+  resultCount: { fontSize: 14, color: '#6b6b6b', fontWeight: '700' },
+
+  // 2열 바둑판 그리드 스타일
+  grid: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between' },
+  card: { width: '48.2%', backgroundColor: '#fff', borderRadius: 18, marginBottom: 14, overflow: 'hidden', borderWidth: 1, borderColor: '#ededed' },
+  cardImageWrap: { width: '100%', height: 160, backgroundColor: '#f9fafb', justifyContent: 'center', alignItems: 'center', position: 'relative' },
+  cardImage: { width: '100%', height: '100%' },
+  cardBody: { padding: 12 },
+  cardTitle: { fontSize: 15, fontWeight: '700', marginBottom: 6, color: '#111' },
+  cardTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 4 },
+  cardTag: { fontSize: 11, color: '#4b5563', backgroundColor: '#f3f4f6', paddingVertical: 4, paddingHorizontal: 8, borderRadius: 6, fontWeight: '500' },
+  countTag: { backgroundColor: '#eff6ff', color: '#1d4ed8' },
+
+  // 이미지 좌상단 뱃지 라벨
+  cardBadge: { position: 'absolute', top: 8, left: 8, paddingHorizontal: 8, paddingVertical: 4, borderRadius: 6 },
+  overloadBadge: { backgroundColor: '#dc2626' },
+  disposeBadge: { backgroundColor: '#d97706' },
+  cardBadgeText: { color: '#fff', fontSize: 10, fontWeight: '800' },
+
   emptyGridPlaceholder: {
-    height: 140,
-    backgroundColor: '#f9fafb',
+    height: 160,
+    backgroundColor: '#fafafa',
     borderRadius: 16,
     borderWidth: 1,
-    borderColor: '#f3f4f6',
-    borderStyle: 'dashed',
+    borderColor: '#eee',
     justifyContent: 'center',
     alignItems: 'center',
     gap: 8,
-    paddingHorizontal: 24,
+    paddingHorizontal: 30,
   },
-  placeholderText: { fontSize: 12, color: '#9ca3af', fontWeight: '500', textAlign: 'center', lineHeight: 18 },
+  placeholderText: { fontSize: 13, color: '#6b6b6b', fontWeight: '600', textAlign: 'center', lineHeight: 20 },
 });

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -1,0 +1,182 @@
+import { Ionicons } from '@expo/vector-icons';
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useState } from 'react';
+import {
+    ActivityIndicator,
+    ScrollView,
+    StyleSheet,
+    Text,
+    View
+} from 'react-native';
+import api from '../_api';
+
+export default function AnalysisScreen() {
+  const [loading, setLoading] = useState(false);
+
+  // 🚨 옷장 분석용 상태 관리 변수들 (과부하 배너 및 처분 제안 스토어)
+  const [overloadData, setOverloadData] = useState<{
+    total_warnings: number;
+    ai_advice: string;
+    items: any[];
+  } | null>(null);
+
+  const [disposalData, setDisposalData] = useState<{
+    items: any[];
+    ai_advice: string;
+  } | null>(null);
+
+  // ✅ 화면이 열리거나 탭이 포커스될 때마다 실시간으로 백엔드 통계 데이터 갱신
+  useFocusEffect(
+    useCallback(() => {
+      let isMounted = true;
+      const loadAnalysisData = async () => {
+        if (!isMounted) return;
+        setLoading(true);
+        try {
+          // 1. 과부하 및 2. 처분 추천 API 동시 병렬 요청
+          const [overloadRes, disposalRes] = await Promise.all([
+            api.get('/stats/overload'),
+            api.get('/stats/dispose', { params: { current_season: '여름' } }),
+          ]);
+
+          if (isMounted) {
+            setOverloadData(overloadRes.data);
+            setDisposalData(disposalRes.data);
+          }
+        } catch (error) {
+          console.error('분석 데이터 로드 실패:', error);
+        } finally {
+          if (isMounted) setLoading(false);
+        }
+      };
+
+      loadAnalysisData();
+      return () => {
+        isMounted = false;
+      };
+    }, [])
+  );
+
+  if (loading && !overloadData && !disposalData) {
+    return (
+      <View style={styles.loadingContainer}>
+        <ActivityIndicator size="large" color="#111" />
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <ScrollView showsVerticalScrollIndicator={false} contentContainerStyle={styles.scrollContent}>
+        {/* 상단 텍스트 영역 */}
+        <View style={styles.headerRow}>
+          <Text style={styles.title}>옷장 진단</Text>
+          <Text style={styles.subtitle}>AI가 내 옷장을 분석하여 스마트한 다이어트를 도와줍니다.</Text>
+        </View>
+
+        {/* 1. 과부하 분석 배너 영역 (Red Theme) */}
+        {overloadData && overloadData.total_warnings > 0 ? (
+          <View style={styles.overloadBannerBox}>
+            <View style={styles.overloadBannerHeader}>
+              <Ionicons name="warning" size={18} color="#dc2626" />
+              <Text style={styles.overloadBannerTitle}>충동 소비 주의보 ({overloadData.total_warnings}건)</Text>
+            </View>
+            <Text style={styles.overloadBannerText}>{overloadData.ai_advice}</Text>
+          </View>
+        ) : (
+          <View style={[styles.overloadBannerBox, styles.safeBannerBox]}>
+            <View style={styles.overloadBannerHeader}>
+              <Ionicons name="checkmark-circle" size={18} color="#16a34a" />
+              <Text style={[styles.overloadBannerTitle, styles.safeBannerTitle]}>옷장 과부하 안전</Text>
+            </View>
+            <Text style={styles.overloadBannerText}>중복되거나 과하게 쌓인 카테고리의 아이템이 없습니다.</Text>
+          </View>
+        )}
+
+        {/* 2. 장기 미착용 의류 처분 제안 배너 영역 (Amber Theme) */}
+        {disposalData && disposalData.items?.length > 0 ? (
+          <View style={styles.disposalBannerBox}>
+            <View style={styles.disposalBannerHeader}>
+              <Ionicons name="trash-outline" size={18} color="#d97706" />
+              <Text style={styles.disposalBannerTitle}>정리가 필요한 옷 제안</Text>
+            </View>
+            <Text style={styles.disposalBannerText}>{disposalData.ai_advice}</Text>
+          </View>
+        ) : (
+          <View style={[styles.disposalBannerBox, styles.safeBannerBox]}>
+            <View style={styles.disposalBannerHeader}>
+              <Ionicons name="heart-outline" size={18} color="#2563eb" />
+              <Text style={[styles.disposalBannerTitle, styles.infoBannerTitle]}>의류 활용도 양호</Text>
+            </View>
+            <Text style={styles.disposalBannerText}>최근 90일 동안 골고루 잘 입고 계시거나 처분할 옷이 없습니다.</Text>
+          </View>
+        )}
+
+        {/* 향후 Step 3에서 채워넣을 데이터 그리드 영역 미리 확보 */}
+        <View style={styles.resultHeader}>
+          <Text style={styles.resultTitle}>주의 필요한 아이템 상세 내역</Text>
+        </View>
+        <View style={styles.emptyGridPlaceholder}>
+          <Ionicons name="layers-outline" size={40} color="#9ca3af" />
+          <Text style={styles.placeholderText}>다음 단계에서 개별 의류 리스트 카드가 이곳에 정렬됩니다.</Text>
+        </View>
+      </ScrollView>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16, paddingTop: 16, backgroundColor: '#fff' },
+  scrollContent: { paddingBottom: 28 },
+  loadingContainer: { flex: 1, backgroundColor: '#fff', justifyContent: 'center', alignItems: 'center' },
+  headerRow: { marginBottom: 20 },
+  title: { fontSize: 28, fontWeight: '800', marginBottom: 6, color: '#111' },
+  subtitle: { fontSize: 14, color: '#6b6b6b', lineHeight: 20 },
+  
+  // 과부하 경고 스타일 (Red)
+  overloadBannerBox: {
+    backgroundColor: '#fef2f2',
+    borderWidth: 1,
+    borderColor: '#fee2e2',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 14,
+  },
+  overloadBannerHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  overloadBannerTitle: { fontSize: 14, fontWeight: '800', color: '#dc2626' },
+  overloadBannerText: { fontSize: 14, color: '#4b5563', lineHeight: 22, fontWeight: '600' },
+  
+  // 처분 제안 스타일 (Amber)
+  disposalBannerBox: {
+    backgroundColor: '#fffbeb',
+    borderWidth: 1,
+    borderColor: '#fef3c7',
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+  },
+  disposalBannerHeader: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 6 },
+  disposalBannerTitle: { fontSize: 14, fontWeight: '800', color: '#d97706' },
+  disposalBannerText: { fontSize: 14, color: '#4b5563', lineHeight: 22, fontWeight: '600' },
+  
+  // 안전 및 정보 알림 서브 스타일
+  safeBannerBox: { backgroundColor: '#f9fafb', borderColor: '#f3f4f6' },
+  safeBannerTitle: { color: '#16a34a' },
+  infoBannerTitle: { color: '#2563eb' },
+
+  resultHeader: { marginTop: 10, marginBottom: 12, paddingHorizontal: 2 },
+  resultTitle: { fontSize: 17, fontWeight: '800', color: '#111' },
+  emptyGridPlaceholder: {
+    height: 140,
+    backgroundColor: '#f9fafb',
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#f3f4f6',
+    borderStyle: 'dashed',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingHorizontal: 24,
+  },
+  placeholderText: { fontSize: 12, color: '#9ca3af', fontWeight: '500', textAlign: 'center', lineHeight: 18 },
+});

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -45,6 +45,7 @@ type OverloadGroup = {
 export default function AnalysisScreen() {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // 🚨 옷장 분석 데이터 저장용 상태 관리 스태이트
   const [overloadData, setOverloadData] = useState<{
@@ -66,6 +67,7 @@ export default function AnalysisScreen() {
         if (!isMounted) return;
         setLoading(true);
         try {
+          setError(null);
           const [overloadRes, disposalRes] = await Promise.all([
             api.get('/stats/overload'),
             api.get('/stats/dispose', { params: { current_season: getCurrentSeason() } }),
@@ -151,6 +153,14 @@ export default function AnalysisScreen() {
     return (
       <View style={styles.loadingContainer}>
         <ActivityIndicator size="large" color="#111" />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.loadingContainer}>
+        <Text style={{ color: '#dc2626', fontSize: 16, fontWeight: 'bold' }}>⚠️ {error}</Text>
       </View>
     );
   }

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -68,7 +68,7 @@ export default function AnalysisScreen() {
         try {
           const [overloadRes, disposalRes] = await Promise.all([
             api.get('/stats/overload'),
-            api.get('/stats/unworn', { params: { current_season: '여름' } }),
+            api.get('/stats/dispose', { params: { current_season: getCurrentSeason() } }),
           ]);
 
           if (isMounted) {
@@ -93,6 +93,15 @@ export default function AnalysisScreen() {
       };
     }, [])
   );
+
+  // 현재 월(Month)을 가져와서 한국어 계절로 반환해 주는 함수
+  const getCurrentSeason = (): string => {
+  const month = new Date().getMonth() + 1;
+  if (month >= 3 && month <= 5) return '봄';
+  if (month >= 6 && month <= 8) return '여름';
+  if (month >= 9 && month <= 11) return '가을';
+  return '겨울';
+}
 
   // 공통 의류 카드 컴포넌트 렌더러 (백엔드 플랫 데이터 매핑)
   const renderClothesCard = (item: any, badgeType?: 'overload' | 'dispose') => {

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -74,10 +74,10 @@ export default function AnalysisScreen() {
           if (isMounted) {
             setOverloadData(overloadRes.data);
 
-            const disposalArray = disposalRes.data || [];
+            const disposalResponse = disposalRes.data;
             setDisposalData({
-              items: disposalArray,
-              ai_advice: '최근 90일 이상 입지 않은 옷들입니다. 처분이나 나눔을 고민해 보세요!',
+              items: disposalResponse.items || [],
+              ai_advice: disposalResponse.ai_advice || '최근 90일 이상 입지 않은 옷들입니다. 처분이나 나눔을 고민해 보세요!',
             });
           }
         } catch (error) {

--- a/ClosetApp/app/(tabs)/analysis.tsx
+++ b/ClosetApp/app/(tabs)/analysis.tsx
@@ -2,15 +2,25 @@ import { Ionicons } from '@expo/vector-icons';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { useCallback, useState } from 'react';
 import {
-    ActivityIndicator,
-    Image,
-    ScrollView,
-    StyleSheet,
-    Text,
-    TouchableOpacity,
-    View,
+  ActivityIndicator,
+  Image,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
 } from 'react-native';
 import api from '../_api';
+
+const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
+
+function resolveImageUri(image?: string | null) {
+  if (!image) return null;
+  if (image.startsWith('http://') || image.startsWith('https://') || image.startsWith('file://')) {
+    return image;
+  }
+  return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
+}
 
 // 백엔드 의류 데이터 규격 정의
 type BackendClothesItem = {
@@ -58,12 +68,17 @@ export default function AnalysisScreen() {
         try {
           const [overloadRes, disposalRes] = await Promise.all([
             api.get('/stats/overload'),
-            api.get('/stats/dispose', { params: { current_season: '여름' } }),
+            api.get('/stats/unworn', { params: { current_season: '여름' } }),
           ]);
 
           if (isMounted) {
             setOverloadData(overloadRes.data);
-            setDisposalData(disposalRes.data);
+
+            const disposalArray = disposalRes.data || [];
+            setDisposalData({
+              items: disposalArray,
+              ai_advice: '최근 90일 이상 입지 않은 옷들입니다. 처분이나 나눔을 고민해 보세요!',
+            });
           }
         } catch (error) {
           console.error('분석 데이터 로드 실패:', error);
@@ -80,10 +95,22 @@ export default function AnalysisScreen() {
   );
 
   // 공통 의류 카드 컴포넌트 렌더러 (백엔드 플랫 데이터 매핑)
-  const renderClothesCard = (item: BackendClothesItem, badgeType?: 'overload' | 'dispose') => {
-    // 혹시 백엔드에서 이미지 스트링이 누락되었을 때 터지지 않게 기본 더미 이미지 처리
-    const imageUri = item.image || 'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?q=80&w=300&auto=format&fit=crop';
+  const renderClothesCard = (item: any, badgeType?: 'overload' | 'dispose') => {
+    const rawImage = item.image ?? item.image_url;
+    const resolvedUri = resolveImageUri(rawImage);
+    const imageUri = resolvedUri || 'https://images.unsplash.com/photo-1523381210434-271e8be1f52b?q=80&w=300&auto=format&fit=crop';
     
+  // ✅ 1. 백엔드 계층형 스펙 반영: tags 객체 내부의 category와 material을 안전하게 참조
+    const displayCategory = item.tags?.category || item.category || '의류';
+    const displayMaterial = item.tags?.material || item.material || '기본';
+    const displayColor = item.tags?.color || item.color || '';
+
+    // ✅ 2. 뱃지 텍스트 동적 분기: 0회 착용이면 [미착용], 그 외에는 [방치됨] 처리
+    let badgeText = '중복';
+    if (badgeType === 'dispose') {
+      badgeText = item.wear_count === 0 ? '미착용' : '방치됨';
+    }
+
     return (
       <TouchableOpacity
         key={item.clothes_id}
@@ -93,18 +120,17 @@ export default function AnalysisScreen() {
       >
         <View style={styles.cardImageWrap}>
           <Image source={{ uri: imageUri }} style={styles.cardImage} resizeMode="contain" />
-          {badgeType === 'overload' && (
-            <View style={[styles.cardBadge, styles.overloadBadge]}><Text style={styles.cardBadgeText}>중복</Text></View>
-          )}
-          {badgeType === 'dispose' && (
-            <View style={[styles.cardBadge, styles.disposeBadge]}><Text style={styles.cardBadgeText}>방치됨</Text></View>
+          {badgeType && (
+            <View style={[styles.cardBadge, badgeType === 'overload' ? styles.overloadBadge : styles.disposeBadge]}>
+              <Text style={styles.cardBadgeText}>{badgeText}</Text>
+            </View>
           )}
         </View>
         <View style={styles.cardBody}>
-          <Text style={styles.cardTitle} numberOfLines={1}>{item.category}</Text>
+          <Text style={styles.cardTitle} numberOfLines={1}>{displayCategory}</Text>
           <View style={styles.cardTagRow}>
-            <Text style={styles.cardTag}>{item.color}</Text>
-            <Text style={styles.cardTag}>{item.material || '기본'}</Text>
+            <Text style={styles.cardTag}>{displayColor}</Text>
+            <Text style={styles.cardTag}>{displayMaterial || '기본'}</Text>
             <Text style={[styles.cardTag, styles.countTag]}>{item.wear_count}회 착용</Text>
           </View>
         </View>

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -1,29 +1,20 @@
 from datetime import datetime, timedelta
 import math
-import httpx, os, requests
+import os
+import requests
 
 # 1. 주소 -> 위경도 변환 (OpenStreetMap Nominatim 사용)
-async def get_coords_from_address(address: str):
+def get_coords_from_address(address: str):
     url = f"https://nominatim.openstreetmap.org/search?q={address}&format=json"
     headers = {"User-Agent": "SmartClosetApp"} # 필수 헤더
     
     try:
-        # 5초 타임아웃 지정 및 비동기 클라이언트 사용
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            response = await client.get(url, headers=headers)
-
-            # HTTP 상태 코드가 정상(200)일 때만 데이터 파싱
-            if response.status_code == 200:
-                data = response.json()
-                if data:
-                    return float(data[0]['lat']), float(data[0]['lon'])
-            
-            # 검색 결과가 없거나 200이 아닌 경우
-            return None, None
-            
-    except Exception as e:
-        # 디버깅을 위해 에러 로그 출력, 시스템 종료 예외는 잡지 않음
-        print(f"[Warning] 주소 변환 API 오류 발생: {e}")
+        response = requests.get(url, headers=headers)
+        data = response.json()
+        if data:
+            return float(data[0]['lat']), float(data[0]['lon'])
+        return None, None
+    except:
         return None, None
     
 def convert_grid(lat, lon):


### PR DESCRIPTION
## 작업 목적
AI 옷장 과부하 분석 및 장기 미착용 의류 처분 제안 스펙을 화면에 독립적으로 녹여내기 위해, 하단 메인 네비게이션 바에 5번째 [진단] 탭 화면을 선제적으로 구현하고 UI 기반을 다집니다.

## 주요 변경 사항
- **하단 네비게이션 바 구조 확장 (`_layout.tsx`)**: 기존 4개 탭 구조에서 의류 진단 전용 화면으로 라우팅할 수 있는 5번째 탭(`analysis`) 단추를 추가했습니다.

- **분석 전용 독립 화면 신설 (`analysis.tsx`)**: 
  - 과부하 데이터를 시각화할 '충동 소비 주의보' 배너(Red)와 방치 의류 조언을 표출할 '처분 제안' 배너(Amber) 레이아웃을 잡았습니다.
  - 데이터 유입 전 혹은 이상적인 옷장 상태일 때 사용자를 배려한 '안전/양호' 알림 가이드 뷰(Gray/Green/Blue) 예외 처리를 선반영했습니다.
  - 네트워크 에러 핸들링 예외 처리: API 실패 시 화면이 먹통이 되거나 빈 화면으로 멈추는 UX 문제를 방지하기 위해, 에러 상태(error)에 따른 직관적인 경고 알림 UI(⚠️ 데이터 로드 실패)를 구현했습니다.

- **실제 백엔드 교차 검증 및 데이터 바인딩 최적화 (리뷰 피드백 반영)**:
  - **`/stats/overload` 연동**: 최신 백엔드 스펙 검증을 통해 `ai_advice` 필드가 정상 존재함을 확인하여 프론트 하드코딩을 제거하고 백엔드 동적 데이터를 100% 동기화했습니다.
  - **`/stats/dispose` 엔드포인트 연동**: 최신 백엔드 스펙에 맞춰 계절 필터링 파라미터를 전달하도록 연동하고, 백엔드로부터 전달되는 객체 구조(`items`, `ai_advice`)를 프론트 규격에 맞게 안전하게 매핑했습니다.
  - **이미지 렌더링 정상화**: 상세 화면의 `resolveImageUri` 주소 해석 로직을 이관하여, 대리 이미지가 아닌 사용자가 등록한 실제 의류 사진이 2열 그리드 카드에 정상 노출되도록 런타임 버그를 해결했습니다.
  - **뱃지 텍스트 분기**: 착용 횟수가 0회인 데이터는 `[방치됨]` 대신 `[미착용]`으로 나오도록 직관적인 가독성을 챙겼습니다.

## 연동 테스트 결과
- 백엔드 로컬 서버 연동 하에 동일 속성 의류 등록 시 배너 및 상세 카드가 누락 없이 정상 렌더링됨을 확인했습니다.
- 백엔드 응답이 순수 배열이 아닌 객체 구조({ items: [...], ai_advice: "..." })로 유입됨에 따라 발생할 수 있는 TypeError(items.map 오류) 및 앱 크래시 현상을 구조 분해 할당 및 널 병합 연산자(|| [])를 활용하여 완벽하게 방어했습니다.

## 관련 이슈
- Closes #171

## 스크린샷
<img width="1079" height="2154" alt="image" src="https://github.com/user-attachments/assets/35a78cc5-d421-4e96-9905-a577979645df" />
