### PR TITLE
[Feature] 옷 상세 화면 가성비(CPW) 점수 산출 및 뱃지 UI 구현 (ZeroDivision 예외 방어)

### DIFF
--- a/ClosetApp/app/(tabs)/index.tsx
+++ b/ClosetApp/app/(tabs)/index.tsx
@@ -137,9 +137,9 @@ useFocusEffect(
           // 기존 과부하 API 호출
           const statsRes = await api.get('/stats/overload');
           
-          // 🚨 [추가] 처분 추천 API 호출 (테스트를 위해 '여름'으로 하드코딩 혹은 로직 추가)
+          // 처분 추천 API 호출
           const disposalRes = await api.get('/stats/dispose', {
-            params: { current_season: '여름' } 
+            params: { current_season: getCurrentSeason() } 
           });
 
           if (isMounted) {
@@ -175,6 +175,14 @@ useFocusEffect(
       },
     ]);
   };
+
+  function getCurrentSeason(): string {
+  const month = new Date().getMonth() + 1;
+  if (month >= 3 && month <= 5) return '봄';
+  if (month >= 6 && month <= 8) return '여름';
+  if (month >= 9 && month <= 11) return '가을';
+  return '겨울';
+  }
 
   const filteredClothes = useMemo(() => {
     return clothes.filter((item) => {

--- a/ClosetApp/app/(tabs)/index.tsx
+++ b/ClosetApp/app/(tabs)/index.tsx
@@ -377,7 +377,7 @@ useFocusEffect(
             )}
 
             {/* 🚨 [추가] 처분 추천 배너 (아이템이 있을 때만 표시) */}
-            {disposalBanner && disposalBanner.items.length > 0 && (
+            {disposalBanner && disposalBanner.items?.length > 0 && (
               <View style={styles.disposalBannerBox}>
                 <View style={styles.disposalBannerHeader}>
                   <Ionicons name="trash-outline" size={16} color="#d97706" />

--- a/ClosetApp/app/(tabs)/index.tsx
+++ b/ClosetApp/app/(tabs)/index.tsx
@@ -94,12 +94,23 @@ export default function HomeScreen() {
   const { clothes, fetchClothes } = useCloset();
   const [loading, setLoading] = useState(false);
 
+  // 🚨 [추가] 백엔드 과부하 통계 데이터 응답 모델을 담아둘 상태 변수
+  const [overloadBanner, setOverloadBanner] = useState<{
+    total_warnings: number;
+    ai_advice: string;
+  } | null>(null);
+
   const [selectedType, setSelectedType] = useState<'전체' | Category>('전체');
   const [showFilter, setShowFilter] = useState(false);
   const [selectedItem, setSelectedItem] = useState<ClothesItem | null>(null);
   const [menuVisible, setMenuVisible] = useState(false);
   const [currentFilterPage, setCurrentFilterPage] = useState(0);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const [disposalBanner, setDisposalBanner] = useState<{
+    items: any[];
+    ai_advice: string;
+  } | null>(null);
 
   const [filter, setFilter] = useState<FilterType>({
     style: '', mood: '', thickness: '', topFit: '', bottomFit: '',
@@ -114,7 +125,7 @@ export default function HomeScreen() {
   const [showAllOptions, setShowAllOptions] = useState<Partial<Record<keyof FilterType, boolean>>>({});
 
   // ✅ 의존성 배열을 빈 배열([])로 설정하고 마운트 상태 락을 걸어 깜빡임/무한 로딩 버그 완벽 수정
-  useFocusEffect(
+useFocusEffect(
     useCallback(() => {
       let isMounted = true;
       const load = async () => {
@@ -122,6 +133,19 @@ export default function HomeScreen() {
         setLoading(true);
         try {
           await fetchClothes();
+          
+          // 기존 과부하 API 호출
+          const statsRes = await api.get('/stats/overload');
+          
+          // 🚨 [추가] 처분 추천 API 호출 (테스트를 위해 '여름'으로 하드코딩 혹은 로직 추가)
+          const disposalRes = await api.get('/stats/dispose', {
+            params: { current_season: '여름' } 
+          });
+
+          if (isMounted) {
+            setOverloadBanner(statsRes.data);
+            setDisposalBanner(disposalRes.data); // 데이터 저장
+          }
         } catch (error) {
           console.error("데이터 로드 실패:", error);
         } finally {
@@ -129,9 +153,7 @@ export default function HomeScreen() {
         }
       };
       load();
-      return () => {
-        isMounted = false;
-      };
+      return () => { isMounted = false; };
     }, [])
   );
 
@@ -198,6 +220,10 @@ export default function HomeScreen() {
             await api.delete(`/clothes/${selectedItem.id}`);
             closeMenu();
             await fetchClothes();
+
+            const statsRes = await api.get('/stats/overload');
+            setOverloadBanner(statsRes.data);
+
           } catch (e) { Alert.alert('삭제 실패'); }
           finally { setDeletingId(null); }
         },
@@ -339,6 +365,28 @@ export default function HomeScreen() {
               </View>
             )}
 
+            {/* 🚨 [추가] 추천 2안 적용: 카테고리 필터와 내 옷장 타이틀 틈새에 과부하 분석 배너 삽입 */}
+            {overloadBanner && overloadBanner.total_warnings > 0 && (
+              <View style={styles.overloadBannerBox}>
+                <View style={styles.overloadBannerHeader}>
+                  <Ionicons name="warning" size={16} color="#dc2626" />
+                  <Text style={styles.overloadBannerTitle}>충동 소비 주의보 ({overloadBanner.total_warnings}건)</Text>
+                </View>
+                <Text style={styles.overloadBannerText}>{overloadBanner.ai_advice}</Text>
+              </View>
+            )}
+
+            {/* 🚨 [추가] 처분 추천 배너 (아이템이 있을 때만 표시) */}
+            {disposalBanner && disposalBanner.items.length > 0 && (
+              <View style={styles.disposalBannerBox}>
+                <View style={styles.disposalBannerHeader}>
+                  <Ionicons name="trash-outline" size={16} color="#d97706" />
+                  <Text style={styles.disposalBannerTitle}>정리가 필요한 옷이 있어요</Text>
+                </View>
+                <Text style={styles.disposalBannerText}>{disposalBanner.ai_advice}</Text>
+              </View>
+            )}
+
             <View style={styles.resultHeader}>
               <Text style={styles.resultTitle}>옷 목록</Text>
               <Text style={styles.resultCount}>{filteredClothes.length}개</Text>
@@ -444,4 +492,57 @@ const styles = StyleSheet.create({
   paginationWrap: { flexDirection: 'row', justifyContent: 'center', marginTop: 12, gap: 6 },
   paginationDot: { width: 8, height: 8, borderRadius: 4, backgroundColor: '#ddd' },
   paginationDotActive: { backgroundColor: '#111', width: 20 },
+
+  // 🚨 [추가] 옷장 과부하 경고 배너용 스타일 테마
+  overloadBannerBox: {
+    backgroundColor: '#fef2f2', 
+    borderWidth: 1, 
+    borderColor: '#fee2e2', 
+    borderRadius: 16, 
+    padding: 14, 
+    marginBottom: 16
+  },
+  overloadBannerHeader: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 6, 
+    marginBottom: 4 
+  },
+  overloadBannerTitle: { 
+    fontSize: 13, 
+    fontWeight: '800', 
+    color: '#dc2626' 
+  },
+  overloadBannerText: { 
+    fontSize: 14, 
+    color: '#4b5563', 
+    lineHeight: 20, 
+    fontWeight: '600' 
+  },
+
+  disposalBannerBox: {
+    backgroundColor: '#fffbeb', // 연한 주황색 바탕
+    borderWidth: 1,
+    borderColor: '#fef3c7',
+    borderRadius: 16,
+    padding: 14,
+    marginBottom: 16,
+  },
+  disposalBannerHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    marginBottom: 4,
+  },
+  disposalBannerTitle: {
+    fontSize: 13,
+    fontWeight: '800',
+    color: '#d97706', // 진한 주황색
+  },
+  disposalBannerText: {
+    fontSize: 14,
+    color: '#4b5563',
+    lineHeight: 20,
+    fontWeight: '600',
+  },
 });

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -14,7 +14,6 @@ import api from './_api';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
 
-// ✅ 1. 관리 팁 데이터를 위한 타입 정의 추가
 interface CareTip {
   "세탁 및 관리": string;
   "보관 방법": string;
@@ -35,6 +34,7 @@ type DetailApiItem = {
   purchase_price?: number | null;
   price?: number | null;
   last_worn_date?: string | null;
+  wear_count?: number; // ✅ 가성비 계산을 위한 착용 횟수 필드 추가
   situation?: string | null; 
   tpo?: string | null;
   tags?: {
@@ -58,7 +58,7 @@ type DetailApiItem = {
   color?: string;
   season?: string;
   style?: string;
-  material?: string; // 소재 정보 추가 매핑용
+  material?: string; 
 };
 
 function resolveImageUri(image?: string | null) {
@@ -69,6 +69,9 @@ function resolveImageUri(image?: string | null) {
   return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
 }
 
+// 뱃지 하이라이트 스타일을 위한 타입 정의
+type HighlightType = 'none' | 'good' | 'normal_cost' | 'warning';
+
 export default function DetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
 
@@ -76,7 +79,6 @@ export default function DetailScreen() {
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
 
-  // ✅ 2. 관리 팁 상태 변수 추가
   const [tipData, setTipData] = useState<TipResponse | null>(null);
   const [tipLoading, setTipLoading] = useState(false);
 
@@ -125,7 +127,6 @@ export default function DetailScreen() {
     }, [fetchDetail])
   );
 
-  // ✅ 3. 옷 상세 정보(item)를 성공적으로 가져오면 관리 팁 API 호출
   useEffect(() => {
     const fetchCareTips = async () => {
       const actualId = item?.id ?? item?.clothes_id;
@@ -144,22 +145,49 @@ export default function DetailScreen() {
     };
 
     fetchCareTips();
-  }, [item?.id, item?.clothes_id]); // ID가 확보될 때만 실행
+  }, [item?.id, item?.clothes_id]);
 
   const visibleTags = useMemo(() => {
     if (!item) return [];
 
     const s = item.tags || {};
     const fitValue = s.top_fit ?? s.topFit ?? s.bottom_fit ?? s.bottomFit ?? '';
-    
     const tpoValue = s.situation ?? s.tpo ?? item.situation ?? item.tpo ?? '';
     
+    // 구매가 및 누적 착용 횟수 세팅
     const rawPrice = item.price ?? item.purchase_price;
+    const wearCount = item.wear_count ?? 0;
+    
     const priceValue = (rawPrice !== null && rawPrice !== undefined)
       ? `${Number(rawPrice).toLocaleString()}원` 
       : '';
 
-    return [
+    // ✅ 가성비(Cost per wear) 산출 로직 및 ZeroDivision 방어
+    let costPerWearStr = '';
+    let costHighlight: HighlightType = 'none';
+    let showCost = false;
+
+    if (rawPrice !== null && rawPrice !== undefined && Number(rawPrice) > 0) {
+      showCost = true;
+      if (wearCount === 0) {
+        // 착용 횟수가 0일 경우 (에러 방어)
+        costPerWearStr = '미착용 (계산 불가)';
+        costHighlight = 'warning';
+      } else {
+        // 정상 나눗셈 계산
+        const costValue = Math.floor(Number(rawPrice) / wearCount);
+        costPerWearStr = `₩${costValue.toLocaleString()} / 회`;
+        
+        // 1회당 비용이 10,000원 이하이면 초록색 뱃지로 '가성비 좋음' 강조
+        if (costValue <= 10000) {
+          costHighlight = 'good';
+        } else {
+          costHighlight = 'normal_cost';
+        }
+      }
+    }
+
+    const tagsArray: Array<{ label: string; value: string | null | undefined; highlight?: HighlightType }> = [
       { label: '이름', value: item.name },
       { label: '카테고리', value: s.category ?? item.category },
       { label: '색상', value: s.color ?? item.color },
@@ -172,9 +200,14 @@ export default function DetailScreen() {
       { label: '두께', value: s.thickness },
       { label: '포인트', value: s.point },
       { label: 'TPO', value: tpoValue },
+      { label: '누적 착용', value: `${wearCount}회` }, // 누적 착용 횟수 표기
       { label: '구매가', value: priceValue },
+      // 조건부 가성비 항목 추가
+      ...(showCost ? [{ label: '가성비', value: costPerWearStr, highlight: costHighlight }] : []),
       { label: '마지막 착용일', value: item.last_worn_date },
-    ].filter(
+    ];
+
+    return tagsArray.filter(
       (tag) =>
         tag.value !== undefined &&
         tag.value !== null &&
@@ -217,18 +250,34 @@ export default function DetailScreen() {
         <Text style={styles.emptyTagText}>표시할 태그가 없습니다.</Text>
       ) : (
         <View style={styles.tagList}>
-          {visibleTags.map((tag) => (
-            <View key={`${tag.label}-${tag.value}`} style={styles.tagRow}>
-              <Text style={styles.tagLabel}>{tag.label}</Text>
-              <View style={styles.tagPill}>
-                <Text style={styles.tagText}>{String(tag.value)}</Text>
+          {visibleTags.map((tag) => {
+            // ✅ 가성비 뱃지 스타일 분기 처리
+            let pillStyle: any[] = [styles.tagPill];
+            let textStyle: any[] = [styles.tagText];
+
+            if (tag.highlight === 'good') {
+              pillStyle.push(styles.goodCostPill);
+              textStyle.push(styles.goodCostText);
+            } else if (tag.highlight === 'normal_cost') {
+              pillStyle.push(styles.normalCostPill);
+              textStyle.push(styles.normalCostText);
+            } else if (tag.highlight === 'warning') {
+              pillStyle.push(styles.warningCostPill);
+              textStyle.push(styles.warningCostText);
+            }
+
+            return (
+              <View key={`${tag.label}-${tag.value}`} style={styles.tagRow}>
+                <Text style={styles.tagLabel}>{tag.label}</Text>
+                <View style={pillStyle}>
+                  <Text style={textStyle}>{String(tag.value)}</Text>
+                </View>
               </View>
-            </View>
-          ))}
+            );
+          })}
         </View>
       )}
 
-      {/* ✅ 4. 관리 팁 UI 섹션 추가 (태그 리스트와 수정 버튼 사이) */}
       {tipLoading ? (
         <ActivityIndicator size="small" color="#111827" style={{ marginBottom: 20 }} />
       ) : tipData ? (
@@ -278,10 +327,21 @@ const styles = StyleSheet.create({
   tagList: { marginBottom: 20 },
   tagRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
   tagLabel: { width: 88, fontSize: 14, color: '#6b7280' },
+  
+  // 기본 태그 스타일
   tagPill: { flexShrink: 1, backgroundColor: '#111827', borderRadius: 999, paddingVertical: 7, paddingHorizontal: 12 },
   tagText: { color: '#fff', fontSize: 14 },
+
+  // ✅ 가성비 뱃지 추가 스타일
+  goodCostPill: { backgroundColor: '#dcfce7', borderWidth: 1, borderColor: '#bbf7d0' },
+  goodCostText: { color: '#166534', fontWeight: '800' }, // 뽕 뽑은 가성비 좋은 옷 (초록)
   
-  // ✅ 5. 관리 팁 관련 스타일
+  normalCostPill: { backgroundColor: '#e0e7ff', borderWidth: 1, borderColor: '#c7d2fe' },
+  normalCostText: { color: '#3730a3', fontWeight: '700' }, // 일반 가성비 (파랑)
+  
+  warningCostPill: { backgroundColor: '#f3f4f6', borderWidth: 1, borderColor: '#e5e7eb' },
+  warningCostText: { color: '#6b7280', fontStyle: 'italic' }, // 미착용 상태 (회색)
+
   tipContainer: { backgroundColor: '#f9fafb', padding: 16, borderRadius: 12, marginBottom: 20, borderWidth: 1, borderColor: '#e5e7eb' },
   tipTitle: { fontSize: 16, fontWeight: '700', marginBottom: 12, color: '#111827' },
   tipBox: { marginBottom: 12 },


### PR DESCRIPTION
## 작업 목적
사용자가 등록한 옷의 '구매 가격'과 '누적 착용 횟수'를 기반으로 1회 착용당 비용(Cost per wear)을 산출하여 상세 화면에 노출함으로써, 합리적인 의류 소비 상태를 한눈에 파악할 수 있도록 UI를 개선하고 관련 예외 버그를 수정합니다.

## 주요 변경 사항
- **가성비 산출 및 동적 뱃지 강조 (`detail.tsx`)**:
  - `구매 가격 / 누적 착용 횟수` 수식을 적용해 1회 착용당 단가를 직관적으로 시각화했습니다.
  - 소비 상태 가독성을 높이기 위해 1회당 비용이 10,000원 이하로 낮아져 '뽕을 뽑은' 합리적인 의류에는 기분 좋은 **초록색 뱃지(`[good]`)**를, 일반 의류에는 **보라색 뱃지**를 동적으로 부여했습니다.
- **착용 횟수 0회 ZeroDivision 완벽 방어 (`detail.tsx`, `schemas.py` 교차 검증)**:
  - 착용 횟수가 `0회`일 경우 나눗셈 연산 오류로 앱이 터지는 현상을 방어하기 위해 조건문 처리를 적용, **`미착용 (계산 불가)` 회색 가이드 뱃지**로 안전하게 예외 처리했습니다.
  - 백엔드 최신 스키마(`schemas.py`)의 `cost_per_wear` Null(None) 예외 처리 스펙과 완벽하게 정합성을 맞춘 2중 방어 구조를 구축했습니다.
- **홈 화면 처분 추천 배너 크래시 에러 수정 (`index.tsx`)**:
  - 백엔드 연동 하에 처분 대상 의류 아이템이 0건으로 유입될 때, `items` 배열이 undefined로 전달되면서 앱이 크래시되는 치명적인 렌더링 오류를 발견했습니다.
  - 자바스크립트 옵셔널 체이닝 문법(`disposalBanner.items?.length`)을 도입하여 백엔드 응답 데이터 유무와 상관없이 홈 화면이 안정적으로 구동되도록 핫픽스(Hot-fix)를 반영했습니다.

## 연동 테스트 결과
- [x] 구매 가격과 착용 횟수가 정상 입력된 의류 진입 시 1회당 비용 정상 연산 및 컬러 뱃지 노출 검증
- [x] 새 옷 혹은 착용 횟수가 0회인 의류 진입 시 런타임 에러(ZeroDivision) 없이 `미착용 (계산 불가)` 정상 노출 검증
- [x] 처분 대상 의류 데이터가 비어 있을 때도 홈 화면 배너에서 에러 없이 유연하게 예외 처리됨을 확인

## 관련 이슈
- Closes #170 

## 스크린샷
<img width="1080" height="2246" alt="image" src="https://github.com/user-attachments/assets/3f49d334-eb9b-4576-90cc-2b1a4a6a66a2" />