### PR TITLE
Enhancement: 옷 상세 화면 태그 리스트 레이아웃 및 색상 톤 개선

### DIFF
--- a/ClosetApp/app/(tabs)/index.tsx
+++ b/ClosetApp/app/(tabs)/index.tsx
@@ -191,7 +191,15 @@ useFocusEffect(
         (!filter.style || item.tags.style === filter.style) &&
         (!filter.mood || item.tags.mood === filter.mood) &&
         (!filter.color || item.tags.color === filter.color) &&
-        (!filter.tpo || item.tags.tpo === filter.tpo);
+        (!filter.tpo || item.tags.tpo === filter.tpo) &&
+        (!filter.season || item.tags.season === filter.season) &&
+        (!filter.tone || item.tags.tone === filter.tone) &&
+        (!filter.topFit || item.tags.topFit === filter.topFit) &&
+        (!filter.bottomFit || item.tags.bottomFit === filter.bottomFit) &&
+        (!filter.material || item.tags.material === filter.material) &&
+        (!filter.thickness || item.tags.thickness === filter.thickness) &&
+        (!filter.point || item.tags.point === filter.point);
+
       return matchType && matchFilter;
     });
   }, [clothes, selectedType, filter]);

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -331,11 +331,13 @@ const styles = StyleSheet.create({
     marginBottom: 20 
   },
   tagRow: { 
-    width: '48%', // 화면의 절반씩 차지하게 설정 (2열 배치)
+    minWidth: '48%', // 화면의 절반씩 차지하게 설정 (2열 배치)
     flexDirection: 'column', // 가로 폭이 좁아지므로 라벨은 위, 뱃지는 아래로 쌓이게 배치
     alignItems: 'flex-start', 
-    marginBottom: 16 
+    marginBottom: 18, // 여백 살짝 조정
+    paddingRight: 8,
   },
+
   tagLabel: { 
     fontSize: 13, 
     color: '#6b7280', 
@@ -343,8 +345,18 @@ const styles = StyleSheet.create({
   },
   
   // 기본 태그 스타일
-  tagPill: { backgroundColor: '#f3f4f6', borderRadius: 999, paddingVertical: 6, paddingHorizontal: 12 },
-  tagText: { color: '#374151', fontSize: 13, fontWeight: '600' },
+  tagPill: { 
+    backgroundColor: '#f3f4f6', 
+    borderRadius: 999, 
+    paddingVertical: 8,
+    paddingHorizontal: 14 
+  },
+
+  tagText: { 
+    color: '#374151', 
+    fontSize: 15, 
+    fontWeight: '600' 
+  },
 
   // ✅ 가성비 뱃지 추가 스타일
   goodCostPill: { backgroundColor: '#dcfce7', borderWidth: 1, borderColor: '#bbf7d0' },

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -324,13 +324,27 @@ const styles = StyleSheet.create({
   imageFallbackText: { color: '#6b7280', fontSize: 15 },
   sectionTitle: { fontSize: 20, fontWeight: '700', marginBottom: 12 },
   emptyTagText: { color: '#6b7280', marginBottom: 20 },
-  tagList: { marginBottom: 20 },
-  tagRow: { flexDirection: 'row', alignItems: 'center', marginBottom: 10 },
-  tagLabel: { width: 88, fontSize: 14, color: '#6b7280' },
+  tagList: { 
+    flexDirection: 'row', 
+    flexWrap: 'wrap', 
+    justifyContent: 'space-between', 
+    marginBottom: 20 
+  },
+  tagRow: { 
+    width: '48%', // 화면의 절반씩 차지하게 설정 (2열 배치)
+    flexDirection: 'column', // 가로 폭이 좁아지므로 라벨은 위, 뱃지는 아래로 쌓이게 배치
+    alignItems: 'flex-start', 
+    marginBottom: 16 
+  },
+  tagLabel: { 
+    fontSize: 13, 
+    color: '#6b7280', 
+    marginBottom: 6 
+  },
   
   // 기본 태그 스타일
-  tagPill: { flexShrink: 1, backgroundColor: '#111827', borderRadius: 999, paddingVertical: 7, paddingHorizontal: 12 },
-  tagText: { color: '#fff', fontSize: 14 },
+  tagPill: { backgroundColor: '#f3f4f6', borderRadius: 999, paddingVertical: 6, paddingHorizontal: 12 },
+  tagText: { color: '#374151', fontSize: 13, fontWeight: '600' },
 
   // ✅ 가성비 뱃지 추가 스타일
   goodCostPill: { backgroundColor: '#dcfce7', borderWidth: 1, borderColor: '#bbf7d0' },


### PR DESCRIPTION
## PR 목적
현재 옷 상세 화면(`detail.tsx`)의 태그 리스트가 세로로 길게 늘어져 있어 공간 효율이 떨어지고, 모든 태그가 진한 검은색으로 되어 있어 UI가 무겁게 느껴지는 문제를 해결했습니다.

## 작업 내용
- **2열 그리드 레이아웃 적용:** 태그 리스트를 2열 바둑판 형태로 배치하여 화면 낭비를 줄이고 스크롤을 최소화했습니다.
- **태그 색상 톤 완화:** 기본 태그의 배경을 연한 회색(`#f3f4f6`)으로, 텍스트를 진회색(`#374151`)으로 변경하여 시각적 피로도를 낮췄습니다.
- **가성비 뱃지 강조:** 기본 태그들의 색상 톤을 빼줌으로써, 맨 하단에 노출되는 가성비 하이라이트 뱃지(초록/파랑)가 더욱 직관적으로 돋보이도록 UI 밸런스를 조정했습니다.
- 홈 화면 필터 누락 버그를 해결하였습니다.

## 📸 확인 사항 (스크린샷)
<img width="1080" height="2130" alt="image" src="https://github.com/user-attachments/assets/7dc0f21a-bb4b-479c-994f-e1759722fb9a" />

## 관련 이슈
- Closes #182 
- Closes #186