### PR TITLE
feat: 월간 옷장 다이어트 시각화 리포트 통합 API 구현

### DIFF
--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -201,3 +201,40 @@ def get_closet_overload(
         "items": detailed_data,
         "ai_advice": advice
     }
+
+
+@router.get("/monthly-report")
+def get_monthly_report(
+    db: Session = Depends(get_db),
+    current_user: User = Depends(get_current_user)
+):
+    # 옷장 생태계 활성도 계산 (최근 30일 기준)
+    thirty_days_ago = (datetime.now() - timedelta(days=30)).date()
+    
+    # 전체 옷 개수
+    total_clothes_count = db.query(Clothes).filter(
+        Clothes.user_id == current_user.id
+    ).count()
+    
+    # 활성 옷 개수 (최근 30일 이내에 입은 기록이 있는 옷)
+    active_clothes_count = db.query(Clothes).filter(
+        Clothes.user_id == current_user.id,
+        Clothes.last_worn_date >= thirty_days_ago
+    ).count()
+    
+    inactive_clothes_count = total_clothes_count - active_clothes_count
+    
+    # 활성도 퍼센트 계산 (0으로 나누는 에러 방지)
+    if total_clothes_count > 0:
+        activity_rate = round((active_clothes_count / total_clothes_count) * 100, 1)
+    else:
+        activity_rate = 0.0
+
+    return {
+        "ecosystem": {
+            "total_clothes": total_clothes_count,
+            "active_clothes": active_clothes_count,
+            "inactive_clothes": inactive_clothes_count,
+            "activity_rate": activity_rate
+        }
+    }

--- a/backend/routers/stats.py
+++ b/backend/routers/stats.py
@@ -230,11 +230,32 @@ def get_monthly_report(
     else:
         activity_rate = 0.0
 
+# 2. 충동구매 방어율 / 과부하 지수
+    overload_data = get_closet_overload(threshold=4, db=db, current_user=current_user)
+    total_warnings = overload_data["total_warnings"]
+    
+    # 프론트엔드 신호등 UI 렌더링을 위한 상태 분기 처리
+    if total_warnings == 0:
+        status_color = "green"
+        status_message = "안전: 완벽한 옷장 다이어트 상태입니다."
+    elif total_warnings <= 2:
+        status_color = "yellow"
+        status_message = "주의: 비슷한 아이템이 모이고 있어요."
+    else:
+        status_color = "red"
+        status_message = "위험: 옷장 다이어트가 시급합니다!"
+
+    # 3. 최종 통합 응답 반환 (기존에 작성한 return 문을 아래 코드로 교체합니다)
     return {
         "ecosystem": {
             "total_clothes": total_clothes_count,
             "active_clothes": active_clothes_count,
             "inactive_clothes": inactive_clothes_count,
             "activity_rate": activity_rate
+        },
+        "overload": {
+            "total_warnings": total_warnings,
+            "status_color": status_color,
+            "status_message": status_message
         }
     }


### PR DESCRIPTION
###  작업 목적
Re:fit 프로젝트의 목표인 **'82% 방치된 옷 문제 해결'**과 **'충동구매 방어'** 성과를 사용자가 직관적으로 체감할 수 있도록, 프론트엔드 시각화(대시보드) 전용 통합 API를 구축했습니다.

###  주요 변경 사항

**1. 월간 리포트 단일 API 추가 (`GET /stats/monthly-report`)**
- 프론트엔드에서 여러 API를 호출할 필요 없이, 단일 호출로 도넛 차트와 신호등 UI를 모두 그릴 수 있도록 데이터를 통합하여 반환합니다.
- 프론트엔드 팀과 합의된 규칙(과부하/가성비 등 복합 통계는 객체로 반환)을 완벽히 준수하여 딕셔너리(`dict`) 형태로 안전하게 직렬화했습니다.

**2. 옷장 생태계 활성도 산출 (도넛 차트용)**
- 사용자의 전체 옷 개수와 최근 30일 이내에 착용 기록(`last_worn_date`)이 있는 활성 옷의 개수를 비교 계산합니다.
- 직관적인 렌더링을 위해 소수점 첫째 자리까지 계산된 `activity_rate`(%) 지표를 함께 반환합니다.

**3. 과부하 지수 연동 (단일 상태 뱃지 UI용)**
- 기존에 작성된 `get_closet_overload` 내부 로직을 100% 재활용하여 중복 임계치(4벌) 경고 횟수를 가져옵니다.
- 경고 횟수(`total_warnings`)에 따라 프론트엔드에서 뱃지 UI 처리가 쉽도록 3단계 상태 색상(`status_color`: "green", "yellow", "red")과 맞춤형 상태 메시지(`status_message`)를 매핑하여 반환합니다.

###  프론트엔드 연동 참고 사항
- **도넛 차트 그리기:** 응답의 `ecosystem.active_clothes`와 `ecosystem.inactive_clothes`로 차트 비율을 나누고, 정중앙에 `ecosystem.activity_rate` 값을 띄워주시면 됩니다!
- **신호등/게이지 그리기:** 응답의 `overload.status_color` 텍스트 값("green", "yellow", "red")에 따라 해당하는 UI의 불빛(Opacity)만 켜주시면 됩니다.

###  관련 이슈
- Resolves #190  