### PR TITLE
Design: AI 코디 추천 화면 UI/UX 전면 개편 및 가독성 최적화

### DIFF
--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -193,12 +193,16 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
         {!apiLoading && apiRecommendations && (
           <View style={{ marginTop: 24 }}>
-            <Text style={styles.sectionTitle}>✨ AI 추천 결과</Text>
-            
-            <View style={styles.contextGroup}>
-              <Text style={styles.contextGroupText}>
-                📍 {recommendContext.address || '위치 알 수 없음'} · 🎯 {recommendContext.situation}
-              </Text>
+
+            <View style={styles.resultHeaderRow}>
+              <View style={styles.contextBadge}>
+                <Ionicons name="location" size={14} color="#64748B" />
+                <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
+              </View>
+              <View style={styles.contextBadge}>
+                <Ionicons name="flag" size={14} color="#64748B" />
+                <Text style={styles.contextBadgeText}>{recommendContext.situation}</Text>
+              </View>
             </View>
 
             <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
@@ -277,8 +281,28 @@ const styles = StyleSheet.create({
   emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
   emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
-  contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
-  contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },
+  resultHeaderRow: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 8, 
+    marginBottom: 16 // 필터와의 간격
+  },
+
+  contextBadge: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    backgroundColor: '#F1F5F9', // 아주 옅은 파스텔 그레이
+    paddingVertical: 6, 
+    paddingHorizontal: 10, 
+    borderRadius: 8, 
+    gap: 4 
+  },
+  
+  contextBadgeText: { 
+    fontSize: 13, 
+    fontWeight: '600', 
+    color: '#475569' 
+  },
 
   aiMessageBox: { 
     backgroundColor: '#F5F8FF', 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -113,24 +113,19 @@ export default function RecommendScreen() {
     }
   };
 
-const handleWearOutfit = async (outfit: OutfitSet) => {
-  try {
-    // 🎯 오늘 날짜를 백엔드 포맷(YYYY-MM-DD)에 맞게 생성
-    const todayStr = new Date().toISOString().slice(0, 10);
-
-    // 선택된 코디에서 존재하는 옷들만 필터링하고 worn_date 필드 필수 추가
-    const payload = [outfit.top, outfit.bottom, outfit.outer, outfit.shoes]
-      .filter(Boolean)
-      .map(cloth => ({
-        clothes_id: Number(cloth!.id),
-        worn_date: todayStr
-      }));
+  const handleWearOutfit = async (outfit: OutfitSet) => {
+    try {
+      const todayStr = new Date().toISOString().slice(0, 10);
+      const payload = [outfit.top, outfit.bottom, outfit.outer, outfit.shoes]
+        .filter(Boolean)
+        .map(cloth => ({
+          clothes_id: Number(cloth!.id),
+          worn_date: todayStr
+        }));
 
     if (payload.length === 0) {
       return Alert.alert('알림', '착용할 옷 정보가 없습니다.');
     }
-
-    console.log('🚀 백엔드로 보낼 데이터 구조:', payload);
 
     await api.post('/history', payload);
     Alert.alert('성공', '오늘의 착용 기록에 저장되었습니다!');
@@ -165,7 +160,7 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
           </View>
 
           <View style={styles.quickKeywordRow}>
-            {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
+            {['데일리', '비즈니스', '데이트', '운동', '미팅'].map(keyword => (
               <TouchableOpacity 
                 key={keyword} 
                 style={styles.quickKeywordChip} 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -359,14 +359,14 @@ const styles = StyleSheet.create({
     fontSize: 15, 
     color: '#1F2937', 
     lineHeight: 26, 
-    fontWeight: '500' // 👈 600에서 400으로 빼서 눈의 피로도를 낮춤
+    fontWeight: '500'
   },
   
   outfitCard: { marginRight: 16, padding: 16, backgroundColor: '#F8FAFC', borderRadius: 20, borderWidth: 1, borderColor: '#E2E8F0', maxHeight: 600, justifyContent: 'space-between' }, 
   outfitCardHeader: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    gap: 6, // 아이콘과 텍스트 사이 간격
+    gap: 6,
     marginBottom: 12 
   },
 
@@ -377,10 +377,10 @@ const styles = StyleSheet.create({
   },
 
   outfitReasonBox: {
-    backgroundColor: '#F1F5F9', 
+    backgroundColor: '#F8FAFC',
     borderLeftWidth: 3,         
-    borderLeftColor: '#94A3B8', 
-    paddingHorizontal: 14,
+    borderLeftColor: '#3B82F6',
+    paddingHorizontal: 12,
     paddingVertical: 12,
     borderTopRightRadius: 8,
     borderBottomRightRadius: 8,
@@ -388,7 +388,7 @@ const styles = StyleSheet.create({
   },
 
   outfitDescription: { 
-    fontSize: 14, 
+    fontSize: 13.5,
     color: '#334155',
     lineHeight: 22,
     fontWeight: '500'

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -202,8 +202,16 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
             </View>
 
             <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-            {aiMessage && <View style={styles.aiMessageBox}><Text style={styles.aiMessageText}>💬 {aiMessage}</Text></View>}
-            
+            {aiMessage && (
+              <View style={styles.aiMessageBox}>
+                <View style={styles.aiMessageHeader}>
+                  <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                  <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+                </View>
+                <Text style={styles.aiMessageText}>{aiMessage}</Text>
+              </View>
+            )}
+
             <ScrollView 
               horizontal 
               showsHorizontalScrollIndicator={false}
@@ -214,9 +222,15 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               {apiRecommendations.map((outfit, index) => (
                 <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
                   <View style={styles.outfitCardHeader}>
+                    <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
                     <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
                   </View>
-                  {outfit.reason && <Text style={styles.outfitDescription}>{outfit.reason}</Text>}
+
+                  {outfit.reason && (
+                    <View style={styles.outfitReasonBox}>
+                      <Text style={styles.outfitDescription}>{outfit.reason}</Text>
+                    </View>
+                  )}
                   
                   {/* 카드가 너무 길어지지 않게 ScrollView 안에 옷 목록 배치 */}
                   <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
@@ -266,13 +280,63 @@ const styles = StyleSheet.create({
   contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
   contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },
 
-  aiMessageBox: { backgroundColor: '#EEF2FF', padding: 20, borderRadius: 16, marginBottom: 20 },
-  aiMessageText: { fontSize: 15, color: '#3730A3', lineHeight: 24, fontWeight: '600' },
+  aiMessageBox: { 
+    backgroundColor: '#F5F8FF', 
+    padding: 20, 
+    borderRadius: 16, 
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: '#E0E7FF'
+  },
+  aiMessageHeader: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 6, 
+    marginBottom: 8 
+  },
+  aiMessageTitle: { 
+    fontSize: 14, 
+    fontWeight: '800', 
+    color: '#4338CA' 
+  },
+  aiMessageText: { 
+    fontSize: 15, 
+    color: '#1F2937', 
+    lineHeight: 26, 
+    fontWeight: '500' // 👈 600에서 400으로 빼서 눈의 피로도를 낮춤
+  },
   
   outfitCard: { marginRight: 16, padding: 16, backgroundColor: '#F8FAFC', borderRadius: 20, borderWidth: 1, borderColor: '#E2E8F0', maxHeight: 600, justifyContent: 'space-between' }, 
-  outfitCardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
-  outfitCardTitle: { fontSize: 20, fontWeight: '800', color: '#111827' },
-  outfitDescription: { fontSize: 14, color: '#64748B', marginBottom: 12, lineHeight: 22 },
+  outfitCardHeader: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 6, // 아이콘과 텍스트 사이 간격
+    marginBottom: 12 
+  },
+
+  outfitCardTitle: { 
+    fontSize: 18, // 폰트 크기 살짝 조정
+    fontWeight: '800', 
+    color: '#111827' 
+  },
+
+  outfitReasonBox: {
+    backgroundColor: '#F1F5F9', // 아주 연한 회색으로 옷 카드와 구분
+    borderLeftWidth: 3,         // 왼쪽에만 선을 그어 답답함 해소
+    borderLeftColor: '#94A3B8', // 차분한 슬레이트 그레이 컬러
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderTopRightRadius: 8,    // 오른쪽만 살짝 둥글게
+    borderBottomRightRadius: 8,
+    marginBottom: 16
+  },
+
+  outfitDescription: { 
+    fontSize: 14, 
+    color: '#334155',
+    lineHeight: 22,
+    fontWeight: '500'
+  },
   
   // ✨ 착용하기 버튼 스타일 추가
   wearButton: { backgroundColor: '#2563EB', paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 'auto' },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -85,7 +85,7 @@ export default function RecommendScreen() {
       const response = await api.get('/recommend/today', { params: { situation, address } });
 
       setRecommendContext({ situation, address });
-      setAiMessage(response.data.ai_message || '');;
+      setAiMessage(response.data.ai_message || '');
       
       // 3. 옷 매칭 로직 (기존과 동일)
       const matched = response.data.outfits.map((outfit: any) => {
@@ -145,9 +145,20 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-      <Text style={styles.title}>코디 추천</Text>
+      <View style={styles.headerTitleRow}>
+        <Text style={styles.title}>코디 추천</Text>
+        <Ionicons name="shirt" size={28} color="#111827" />
+      </View>
+      <Text style={styles.headerSubtitle}>오늘의 날씨와 외출 목적에 맞는 스타일링</Text>
+
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
+        
+        {/* 2. 변경된 섹션 타이틀 영역 */}
+        <View style={styles.sectionTitleRow}>
+          <Ionicons name="partly-sunny" size={22} color="#2563EB" />
+          <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
+        </View>
+        
         <View style={styles.inputBox}>
           <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
         </View>
@@ -235,9 +246,12 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#F4F6F8' },
   content: { padding: 16, paddingBottom: 40 },
-  title: { fontSize: 30, fontWeight: '800', color: '#111827', marginBottom: 20 },
+  title: { fontSize: 30, fontWeight: '800', color: '#111827', marginBottom: 4 },
+  headerTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 4 },
+  headerSubtitle: { fontSize: 14, color: '#64748B', marginBottom: 20 },
   section: { backgroundColor: '#FFFFFF', borderRadius: 24, padding: 20, marginBottom: 20 },
-  sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 8 },
+  sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 0 },
+  sectionTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 12 },
   inputBox: { backgroundColor: '#F9FAFB', borderRadius: 16, padding: 16, marginBottom: 16, borderWidth: 1, borderColor: '#F1F5F9' },
   textInput: { fontSize: 16, color: '#111827', fontWeight: '600' },
   quickKeywordRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 20 },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -145,56 +145,60 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+      {/* 고정된 상단 헤더 */}
       <View style={styles.headerTitleRow}>
         <Text style={styles.title}>코디 추천</Text>
         <Ionicons name="shirt" size={28} color="#111827" />
       </View>
       <Text style={styles.headerSubtitle}>오늘의 날씨와 외출 목적에 맞는 스타일링</Text>
 
-      <View style={styles.section}>
-        
-        {/* 2. 변경된 섹션 타이틀 영역 */}
-        <View style={styles.sectionTitleRow}>
-          <Ionicons name="partly-sunny" size={22} color="#2563EB" />
-          <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
-        </View>
-        
-        <View style={styles.inputBox}>
-          <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
-        </View>
-
-        <View style={styles.quickKeywordRow}>
-          {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
-            <TouchableOpacity 
-              key={keyword} 
-              style={styles.quickKeywordChip} 
-              onPress={() => setSituation(keyword)}
-            >
-              <Text style={styles.quickKeywordText}>{keyword}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-
-        <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
-          <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
-        </TouchableOpacity>
-
-        {apiLoading && <SkeletonLoader />}
-
-        {!apiLoading && !apiRecommendations && (
-          <View style={styles.emptyStateContainer}>
-            <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
-            <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
-            <Text style={styles.emptyStateDesc}>
-              오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
-            </Text>
+      {/* ✨ 1. 추천 결과가 '없을 때'만 보여주는 폼 영역 */}
+      {!apiRecommendations && (
+        <View style={styles.section}>
+          <View style={styles.sectionTitleRow}>
+            <Ionicons name="partly-sunny" size={22} color="#2563EB" />
+            <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
           </View>
-        )}
+          
+          <View style={styles.inputBox}>
+            <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
+          </View>
 
-        {!apiLoading && apiRecommendations && (
-          <View style={{ marginTop: 24 }}>
+          <View style={styles.quickKeywordRow}>
+            {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
+              <TouchableOpacity 
+                key={keyword} 
+                style={styles.quickKeywordChip} 
+                onPress={() => setSituation(keyword)}
+              >
+                <Text style={styles.quickKeywordText}>{keyword}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
 
-            <View style={styles.resultHeaderRow}>
+          <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
+            <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
+          </TouchableOpacity>
+
+          {apiLoading && <SkeletonLoader />}
+
+          {!apiLoading && (
+            <View style={styles.emptyStateContainer}>
+              <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
+              <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
+              <Text style={styles.emptyStateDesc}>
+                오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* ✨ 2. 추천 결과가 '나왔을 때' 보여주는 결과 전용 화면 (폼은 숨겨짐) */}
+      {apiRecommendations && (
+        <View style={styles.section}>
+          <View style={styles.resultHeaderRow}>
+            <View style={{ flexDirection: 'row', gap: 8, flex: 1 }}>
               <View style={styles.contextBadge}>
                 <Ionicons name="location" size={14} color="#64748B" />
                 <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
@@ -205,58 +209,63 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               </View>
             </View>
 
-            <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-            {aiMessage && (
-              <View style={styles.aiMessageBox}>
-                <View style={styles.aiMessageHeader}>
-                  <Ionicons name="sparkles" size={16} color="#4F46E5" />
-                  <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
-                </View>
-                <Text style={styles.aiMessageText}>{aiMessage}</Text>
-              </View>
-            )}
-
-            <ScrollView 
-              horizontal 
-              showsHorizontalScrollIndicator={false}
-              snapToInterval={CARD_WIDTH + 16}
-              decelerationRate="fast"
-              contentContainerStyle={{ paddingRight: 16, paddingBottom: 10 }}
-            >
-              {apiRecommendations.map((outfit, index) => (
-                <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
-                  <View style={styles.outfitCardHeader}>
-                    <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
-                    <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
-                  </View>
-
-                  {outfit.reason && (
-                    <View style={styles.outfitReasonBox}>
-                      <Text style={styles.outfitDescription}>{outfit.reason}</Text>
-                    </View>
-                  )}
-                  
-                  {/* 카드가 너무 길어지지 않게 ScrollView 안에 옷 목록 배치 */}
-                  <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
-                    {(displayFilter === '전체' || displayFilter === '상의') && outfit.top && <OutfitItemCard label="상의" item={outfit.top} />}
-                    {(displayFilter === '전체' || displayFilter === '하의') && outfit.bottom && <OutfitItemCard label="하의" item={outfit.bottom} />}
-                    {(displayFilter === '전체' || displayFilter === '아우터') && outfit.outer && <OutfitItemCard label="아우터" item={outfit.outer} />}
-                    {(displayFilter === '전체' || displayFilter === '신발') && outfit.shoes && <OutfitItemCard label="신발" item={outfit.shoes} />}
-                  </ScrollView>
-
-                  {/* ✨ 추가된 기능: 추천 코디 착용하기 버튼 */}
-                  <TouchableOpacity 
-                    style={styles.wearButton} 
-                    onPress={() => handleWearOutfit(outfit)}
-                  >
-                    <Text style={styles.wearButtonText}>이 코디 착용하기</Text>
-                  </TouchableOpacity>
-                </View>
-              ))}
-            </ScrollView>
+            {/* ✨ 다시 검색 버튼 */}
+            <TouchableOpacity style={styles.resetButton} onPress={() => setApiRecommendations(null)}>
+              <Ionicons name="refresh" size={14} color="#475569" />
+              <Text style={styles.resetButtonText}>다시 검색</Text>
+            </TouchableOpacity>
           </View>
-        )}
-      </View>
+
+          <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
+          
+          {aiMessage && (
+            <View style={styles.aiMessageBox}>
+              <View style={styles.aiMessageHeader}>
+                <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+              </View>
+              <Text style={styles.aiMessageText}>{aiMessage}</Text>
+            </View>
+          )}
+
+          <ScrollView 
+            horizontal 
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={CARD_WIDTH + 16}
+            decelerationRate="fast"
+            contentContainerStyle={{ paddingRight: 16, paddingBottom: 10 }}
+          >
+            {apiRecommendations.map((outfit, index) => (
+              <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
+                <View style={styles.outfitCardHeader}>
+                  <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
+                  <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
+                </View>
+
+                {outfit.reason && (
+                  <View style={styles.outfitReasonBox}>
+                    <Text style={styles.outfitDescription}>{outfit.reason}</Text>
+                  </View>
+                )}
+                
+                <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
+                  {(displayFilter === '전체' || displayFilter === '상의') && outfit.top && <OutfitItemCard label="상의" item={outfit.top} />}
+                  {(displayFilter === '전체' || displayFilter === '하의') && outfit.bottom && <OutfitItemCard label="하의" item={outfit.bottom} />}
+                  {(displayFilter === '전체' || displayFilter === '아우터') && outfit.outer && <OutfitItemCard label="아우터" item={outfit.outer} />}
+                  {(displayFilter === '전체' || displayFilter === '신발') && outfit.shoes && <OutfitItemCard label="신발" item={outfit.shoes} />}
+                </ScrollView>
+
+                <TouchableOpacity 
+                  style={styles.wearButton} 
+                  onPress={() => handleWearOutfit(outfit)}
+                >
+                  <Text style={styles.wearButtonText}>이 코디 착용하기</Text>
+                </TouchableOpacity>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      )}
     </ScrollView>
   );
 }
@@ -297,8 +306,24 @@ const styles = StyleSheet.create({
     borderRadius: 8, 
     gap: 4 
   },
-  
+
   contextBadgeText: { 
+    fontSize: 13, 
+    fontWeight: '600', 
+    color: '#475569' 
+  },
+
+  resetButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#E2E8F0',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    gap: 4
+  },
+  
+  resetButtonText: { 
     fontSize: 13, 
     fontWeight: '600', 
     color: '#475569' 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from '@expo/vector-icons';
 import * as Location from 'expo-location';
 import { useEffect, useState } from 'react';
 import {
@@ -150,11 +151,34 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
         <View style={styles.inputBox}>
           <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
         </View>
+
+        <View style={styles.quickKeywordRow}>
+          {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
+            <TouchableOpacity 
+              key={keyword} 
+              style={styles.quickKeywordChip} 
+              onPress={() => setSituation(keyword)}
+            >
+              <Text style={styles.quickKeywordText}>{keyword}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
         <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
           <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
         </TouchableOpacity>
 
         {apiLoading && <SkeletonLoader />}
+
+        {!apiLoading && !apiRecommendations && (
+          <View style={styles.emptyStateContainer}>
+            <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
+            <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
+            <Text style={styles.emptyStateDesc}>
+              오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
+            </Text>
+          </View>
+        )}
 
         {!apiLoading && apiRecommendations && (
           <View style={{ marginTop: 24 }}>
@@ -216,8 +240,14 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 8 },
   inputBox: { backgroundColor: '#F9FAFB', borderRadius: 16, padding: 16, marginBottom: 16, borderWidth: 1, borderColor: '#F1F5F9' },
   textInput: { fontSize: 16, color: '#111827', fontWeight: '600' },
+  quickKeywordRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 20 },
+  quickKeywordChip: { backgroundColor: '#F1F5F9', paddingVertical: 8, paddingHorizontal: 14, borderRadius: 20 },
+  quickKeywordText: { fontSize: 13, color: '#475569', fontWeight: '600' },
   actionButton: { backgroundColor: '#111827', borderRadius: 16, paddingVertical: 16, alignItems: 'center' },
   actionButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+  emptyStateContainer: { alignItems: 'center', justifyContent: 'center', paddingVertical: 60, paddingHorizontal: 20 },
+  emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
+  emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
   contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
   contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -74,7 +74,7 @@ export default function RecommendScreen() {
     try {
       setApiLoading(true);
       
-      // 1. 위치 정보는 정상적으로 가져옴 (테스트 환경에서도 중요)
+      // 1. 위치 정보는 정상적으로 가져옴
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') return Alert.alert('권한 필요', '위치 권한이 필요합니다.');
 
@@ -118,12 +118,12 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
     // 🎯 오늘 날짜를 백엔드 포맷(YYYY-MM-DD)에 맞게 생성
     const todayStr = new Date().toISOString().slice(0, 10);
 
-    // 선택된 코디에서 존재하는 옷들만 필터링하고 worn_date 필드 필수 추가!
+    // 선택된 코디에서 존재하는 옷들만 필터링하고 worn_date 필드 필수 추가
     const payload = [outfit.top, outfit.bottom, outfit.outer, outfit.shoes]
       .filter(Boolean)
       .map(cloth => ({
         clothes_id: Number(cloth!.id),
-        worn_date: todayStr // 👈 이 필드가 누락되어 422 에러가 났던 것입니다.
+        worn_date: todayStr
       }));
 
     if (payload.length === 0) {
@@ -197,36 +197,28 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
       {/* ✨ 2. 추천 결과가 '나왔을 때' 보여주는 결과 전용 화면 (폼은 숨겨짐) */}
       {apiRecommendations && (
         <View style={styles.section}>
+          
+          {/* ✨ 양쪽 정렬로 깔끔하게 정리된 헤더 */}
           <View style={styles.resultHeaderRow}>
-            <View style={{ flexDirection: 'row', gap: 8, flex: 1 }}>
-              <View style={styles.contextBadge}>
-                <Ionicons name="location" size={14} color="#64748B" />
-                <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
+            <View style={{ flexDirection: 'row', gap: 8 }}>
+              <View style={styles.locationBadge}>
+                <Ionicons name="location" size={12} color="#64748B" />
+                <Text style={styles.locationBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
               </View>
-              <View style={styles.contextBadge}>
-                <Ionicons name="flag" size={14} color="#64748B" />
-                <Text style={styles.contextBadgeText}>{recommendContext.situation}</Text>
+              <View style={styles.tpoBadge}>
+                <Ionicons name="flag" size={12} color="#2563EB" />
+                <Text style={styles.tpoBadgeText}>{recommendContext.situation}</Text>
               </View>
             </View>
 
-            {/* ✨ 다시 검색 버튼 */}
+            {/* ✨ 회색 덩어리를 없애고 가벼운 텍스트 버튼으로 우측 배치 */}
             <TouchableOpacity style={styles.resetButton} onPress={() => setApiRecommendations(null)}>
-              <Ionicons name="refresh" size={14} color="#475569" />
+              <Ionicons name="refresh" size={14} color="#64748B" />
               <Text style={styles.resetButtonText}>다시 검색</Text>
             </TouchableOpacity>
           </View>
 
           <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-          
-          {aiMessage && (
-            <View style={styles.aiMessageBox}>
-              <View style={styles.aiMessageHeader}>
-                <Ionicons name="sparkles" size={16} color="#4F46E5" />
-                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
-              </View>
-              <Text style={styles.aiMessageText}>{aiMessage}</Text>
-            </View>
-          )}
 
           <ScrollView 
             horizontal 
@@ -264,6 +256,17 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               </View>
             ))}
           </ScrollView>
+
+          {aiMessage && (
+            <View style={styles.aiMessageBox}>
+              <View style={styles.aiMessageHeader}>
+                <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+              </View>
+              <Text style={styles.aiMessageText}>{aiMessage}</Text>
+            </View>
+          )}
+
         </View>
       )}
     </ScrollView>
@@ -290,44 +293,48 @@ const styles = StyleSheet.create({
   emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
   emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
+ 
   resultHeaderRow: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    gap: 8, 
-    marginBottom: 16 // 필터와의 간격
+    justifyContent: 'space-between',
+    marginBottom: 16
   },
 
-  contextBadge: { 
+
+  locationBadge: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    backgroundColor: '#F1F5F9', // 아주 옅은 파스텔 그레이
+    backgroundColor: '#F1F5F9', 
     paddingVertical: 6, 
     paddingHorizontal: 10, 
     borderRadius: 8, 
     gap: 4 
   },
+  locationBadgeText: { fontSize: 13, fontWeight: '600', color: '#475569' },
 
-  contextBadgeText: { 
-    fontSize: 13, 
-    fontWeight: '600', 
-    color: '#475569' 
+
+  tpoBadge: {
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    backgroundColor: '#EFF6FF', 
+    paddingVertical: 6, 
+    paddingHorizontal: 10, 
+    borderRadius: 8, 
+    gap: 4,
+    borderWidth: 1,
+    borderColor: '#BFDBFE' 
   },
+  tpoBadgeText: { fontSize: 13, fontWeight: '700', color: '#1D4ED8' }, 
 
   resetButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#E2E8F0',
+    gap: 4,
     paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    gap: 4
+    paddingHorizontal: 8,
   },
-  
-  resetButtonText: { 
-    fontSize: 13, 
-    fontWeight: '600', 
-    color: '#475569' 
-  },
+  resetButtonText: { fontSize: 13, fontWeight: '600', color: '#64748B' },
 
   aiMessageBox: { 
     backgroundColor: '#F5F8FF', 
@@ -370,12 +377,12 @@ const styles = StyleSheet.create({
   },
 
   outfitReasonBox: {
-    backgroundColor: '#F1F5F9', // 아주 연한 회색으로 옷 카드와 구분
-    borderLeftWidth: 3,         // 왼쪽에만 선을 그어 답답함 해소
-    borderLeftColor: '#94A3B8', // 차분한 슬레이트 그레이 컬러
+    backgroundColor: '#F1F5F9', 
+    borderLeftWidth: 3,         
+    borderLeftColor: '#94A3B8', 
     paddingHorizontal: 14,
     paddingVertical: 12,
-    borderTopRightRadius: 8,    // 오른쪽만 살짝 둥글게
+    borderTopRightRadius: 8,
     borderBottomRightRadius: 8,
     marginBottom: 16
   },
@@ -387,7 +394,7 @@ const styles = StyleSheet.create({
     fontWeight: '500'
   },
   
-  // ✨ 착용하기 버튼 스타일 추가
+
   wearButton: { backgroundColor: '#2563EB', paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 'auto' },
   wearButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
 

--- a/ClosetApp/components/recommend/OutfitItemCard.tsx
+++ b/ClosetApp/components/recommend/OutfitItemCard.tsx
@@ -65,13 +65,34 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
 }
 
 const styles = StyleSheet.create({
-  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12 },
-  itemHeaderRow: { flexDirection: 'row', marginBottom: 10 },
-  itemBadge: { backgroundColor: '#F3F4F6', color: '#4B5563', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
-  itemImageContainer: { width: '100%', height: 200, backgroundColor: '#F3F4F6', borderRadius: 12, marginBottom: 12, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' },
+  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 12 },
+  itemHeaderRow: { flexDirection: 'row', marginBottom: 12 },
+  itemBadge: { backgroundColor: '#F1F5F9', color: '#475569', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
+  
+  itemImageContainer: { 
+    width: '100%', 
+    height: 280,
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12, 
+    marginBottom: 12, 
+    alignItems: 'center', 
+    justifyContent: 'center', 
+    overflow: 'hidden'
+  },
+
   itemImage: { width: '100%', height: '100%' },
-  imagePlaceholder: { width: '100%', height: 200, borderRadius: 12, backgroundColor: '#E5E7EB', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },
-  imagePlaceholderText: { fontSize: 13, color: '#6B7280', fontWeight: '600' },
-  itemName: { fontSize: 17, fontWeight: '800', color: '#111827', marginBottom: 10 },
+
+  imagePlaceholder: { 
+    width: '100%', 
+    height: 280, 
+    borderRadius: 12, 
+    backgroundColor: '#F8FAFC', 
+    alignItems: 'center', 
+    justifyContent: 'center', 
+    marginBottom: 12 
+  },
+  
+  imagePlaceholderText: { fontSize: 13, color: '#94A3B8', fontWeight: '600' },
+  itemName: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 12 },
   tagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
 });

--- a/ClosetApp/components/recommend/OutfitItemCard.tsx
+++ b/ClosetApp/components/recommend/OutfitItemCard.tsx
@@ -65,10 +65,9 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
 }
 
 const styles = StyleSheet.create({
-  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12, borderWidth: 1, borderColor: '#EEF2F7' },
+  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12 },
   itemHeaderRow: { flexDirection: 'row', marginBottom: 10 },
-  itemBadge: { backgroundColor: '#E8EEF9', color: '#2563EB', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
-  // ✨ Commit 1: 카드 리팩토링 (회색 배경 컨테이너 추가로 이미지와 카드 분리)
+  itemBadge: { backgroundColor: '#F3F4F6', color: '#4B5563', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
   itemImageContainer: { width: '100%', height: 200, backgroundColor: '#F3F4F6', borderRadius: 12, marginBottom: 12, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' },
   itemImage: { width: '100%', height: '100%' },
   imagePlaceholder: { width: '100%', height: 200, borderRadius: 12, backgroundColor: '#E5E7EB', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },


### PR DESCRIPTION
## PR 목적 및 개요
추천 화면(`RecommendScreen`)의 전반적인 레이아웃과 디자인을 개선하여, 사용자가 앱 진입부터 코디 결과를 확인하기까지의 흐름을 훨씬 매끄럽고 쾌적하게 만들었습니다. 시각적 노이즈를 걷어내어 핵심 콘텐츠인 '옷 사진'이 가장 돋보이도록 UI를 클렌징했습니다.

## 상세 작업 내용
**1. UX 흐름 개선 및 화면 전환**
- 코디 추천 완료 시 화면 상단의 거대한 입력 폼(`section`)을 숨기고 결과 뷰로 전환되도록 조건부 렌더링을 적용했습니다.
- 입력 폼이 사라진 대신 상단 헤더 우측에 `다시 검색` 버튼을 배치하여 언제든 재입력이 가능하게 했습니다.
- 빈 화면(Empty State) 안내 UI와 '데이트', '출근' 등의 빠른 키워드 입력 칩을 추가했습니다.

**2. 레이아웃 재배치 및 가독성 확보**
- 공간을 많이 차지하던 'AI 스타일링 포인트' 메시지를 화면 하단으로 내려, 스크롤 없이 코디 이미지가 먼저 보이도록(Above the fold) 최적화했습니다.
- 코디 추천 설명 영역(Reason)에 인용구 스타일(좌측 파란색 보더라인, 옅은 배경색)을 적용하고 텍스트 줄 간격과 크기를 줄여 컴팩트하게 정리했습니다.
- 위치와 TPO(상황) 텍스트를 귀여운 뱃지(Badge) 형태로 묶어 상단에 배치하고 포인트 컬러를 주었습니다.

**3. 이미지 카드(`OutfitItemCard`) 리팩토링**
- 카드 컴포넌트의 불필요한 테두리(border)를 제거하여 박스-인-박스 구조를 해소했습니다.
- 옷 이미지가 들어가는 컨테이너의 높이를 `280`으로 대폭 확장하고, 연한 회색 배경(`F8FAFC`)을 주어 고급 쇼핑몰처럼 쾌적하게 렌더링 되도록 변경했습니다.
- `TagChip`과 카테고리 뱃지들의 색상을 톤다운하여 시선이 옷 이미지로 집중되도록 유도했습니다.

## 기존 추천 화면
<img width="250" alt="image" src="https://github.com/user-attachments/assets/ed7a6927-428e-4c1b-ad4d-a4f3f527646f" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5c7b831b-7331-4905-bc73-2dc0a1034c86" />

## 개선 추천 화면
<img width="250" alt="image" src="https://github.com/user-attachments/assets/02242bc8-da11-4efa-bda0-d8b0ac5ec5e8" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/c74ef3cc-9f67-4c38-a85f-bc9c59bb0903" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/387a5fb4-8a5e-48f6-a0dd-7b70141b985e" />

## 관련 이슈
- Resolves #194