### PR TITLE
[Design/Fix] 착용 기록 상세 화면 전면 개편 및 UX 고도화

### DIFF
--- a/ClosetApp/app.json
+++ b/ClosetApp/app.json
@@ -38,7 +38,8 @@
             "backgroundColor": "#000000"
           }
         }
-      ]
+      ],
+      "@react-native-community/datetimepicker"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -345,7 +345,12 @@ export default function HistoryScreen() {
         data={groupedHistoryData}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => {
-          const clothes = getClothesByIds(item.clothesIds);
+          // ✨ 카테고리 순서(아우터 > 상의 > 하의 > 신발 > 악세사리 > 기타)대로 정렬
+          const clothes = getClothesByIds(item.clothesIds).sort((a, b) => {
+            const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
+            return (order[a.category] || 99) - (order[b.category] || 99);
+          });
+          
           const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
           
           let displayDate = item.date;
@@ -360,7 +365,7 @@ export default function HistoryScreen() {
             <View style={styles.card}>
               <Text style={styles.date}>{displayDate}</Text>
 
-              {/* ✨ 1. 카테고리를 위로 올리고, 사진 잘림(Crop) 현상을 해결한 스크롤 영역 */}
+              {/* 1. 카테고리를 위로 올리고, 사진 잘림(Crop) 현상을 해결한 스크롤 영역 */}
               <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>
                 {clothes.length > 0 ? (
                   clothes.map((cloth) => (
@@ -387,7 +392,7 @@ export default function HistoryScreen() {
                 )}
               </ScrollView>
 
-              {/* ✨ 2. 태그와 메모를 은은한 회색 박스로 묶고 아이콘 추가 */}
+              {/* 2. 태그와 메모를 은은한 회색 박스로 묶고 아이콘 추가 */}
               <View style={styles.metaContainer}>
                 <View style={styles.metaRow}>
                   <Ionicons name="pricetag" size={14} color="#3B82F6" />
@@ -444,7 +449,7 @@ const styles = StyleSheet.create({
   card: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
   date: { fontSize: 16, fontWeight: '700', color: '#111', marginBottom: 10 },
   
-  // ✨ 옷 이미지 썸네일 관련 스타일 모음
+  // 옷 이미지 썸네일 관련 스타일 모음
   clothesScroll: { gap: 14, paddingBottom: 12 },
   clothThumbnailBox: { width: 110, alignItems: 'center' },
   clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 6 },
@@ -462,7 +467,7 @@ const styles = StyleSheet.create({
   clothName: { fontSize: 13, fontWeight: '600', color: '#1E293B', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
   
-  // ✨ 태그/메모 스타일
+  // 태그/메모 스타일
   metaContainer: { 
     backgroundColor: '#F8FAFC', 
     padding: 12, 

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,4 +1,5 @@
 import { Ionicons } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { router, useFocusEffect } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import {
@@ -6,6 +7,7 @@ import {
   Alert,
   FlatList,
   Image,
+  Platform,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -96,6 +98,11 @@ function mapApiHistoryToUi(item: HistoryApiItem): WearHistoryItem {
 
 export default function HistoryScreen() {
   const [selectedFilter, setSelectedFilter] = useState('전체');
+  
+  // ✨ 날짜 필터링 상태 추가
+  const [filterDate, setFilterDate] = useState<Date | null>(null);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  
   const [historyList, setHistoryList] = useState<WearHistoryItem[]>([]);
   const [clothesMap, setClothesMap] = useState<Record<string, ClothingItem>>({});
   const [loading, setLoading] = useState(true);
@@ -112,42 +119,28 @@ export default function HistoryScreen() {
 
   const fetchHistoryList = useCallback(async (isRefresh = false) => {
     try {
-      if (isRefresh) {
-        setRefreshing(true);
-      } else {
-        setLoading(true);
-      }
+      if (isRefresh) setRefreshing(true);
+      else setLoading(true);
       setErrorMessage('');
 
       const response = await api.get('/history');
       const data: HistoryApiItem[] = Array.isArray(response.data) ? response.data : [];
-
       const mappedHistoryList = data.map(mapApiHistoryToUi);
 
       const nextClothesMap: Record<string, ClothingItem> = {};
       data.forEach((item) => {
-        const clothesId =
-          item.clothes?.clothes_id?.toString() ??
-          item.clothes_id?.toString() ??
-          '';
-
+        const clothesId = item.clothes?.clothes_id?.toString() ?? item.clothes_id?.toString() ?? '';
         if (!clothesId) return;
 
-        const category = item.clothes?.category ?? item.clothes?.tags?.category ?? '미분류';
-        const color = item.clothes?.color ?? item.clothes?.tags?.color ?? '색상 정보 없음';
-
         const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
-        
         const rawImageUrl = item.clothes?.image_url;
-        const fullImageUrl = rawImageUrl 
-          ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`)
-          : undefined;
+        const fullImageUrl = rawImageUrl ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`) : undefined;
 
         nextClothesMap[clothesId] = {
           id: clothesId,
           name: item.clothes?.name ?? `옷 ${clothesId}`,
-          category: category,
-          color: color,
+          category: item.clothes?.category ?? item.clothes?.tags?.category ?? '미분류',
+          color: item.clothes?.color ?? item.clothes?.tags?.color ?? '색상 정보 없음',
           imageUrl: fullImageUrl,
         };
       });
@@ -156,13 +149,8 @@ export default function HistoryScreen() {
       setClothesMap(nextClothesMap);
     } catch (error: any) {
       console.error('기록 불러오기 실패:', error);
-      if (error.response?.status === 401) {
-        setErrorMessage('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
-      } else {
-        setErrorMessage(
-          error.response?.data?.detail || error.message || '기록을 불러오지 못했습니다.'
-        );
-      }
+      if (error.response?.status === 401) setErrorMessage('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
+      else setErrorMessage(error.response?.data?.detail || error.message || '기록을 불러오지 못했습니다.');
     } finally {
       setLoading(false);
       setRefreshing(false);
@@ -175,12 +163,32 @@ export default function HistoryScreen() {
     }, [fetchHistoryList])
   );
 
-  const groupedHistoryData = useMemo(() => {
-    const filtered =
-      selectedFilter === '전체'
-        ? historyList
-        : historyList.filter((item) => item.tpo === selectedFilter);
+  // ✨ 선택된 날짜를 API 날짜 포맷(YYYY-MM-DD)으로 변환
+  const formattedFilterDate = filterDate 
+    ? `${filterDate.getFullYear()}-${String(filterDate.getMonth() + 1).padStart(2, '0')}-${String(filterDate.getDate()).padStart(2, '0')}`
+    : null;
 
+  const handleDateChange = (event: any, date?: Date) => {
+    if (Platform.OS === 'android') setShowDatePicker(false);
+    if (event.type === 'dismissed') {
+      return;
+    }
+    if (date) setFilterDate(date);
+  };
+
+  const groupedHistoryData = useMemo(() => {
+    // ✨ 1단계: TPO 및 날짜 필터링 적용
+    let filtered = historyList;
+    
+    if (selectedFilter !== '전체') {
+      filtered = filtered.filter((item) => item.tpo === selectedFilter);
+    }
+    
+    if (formattedFilterDate) {
+      filtered = filtered.filter((item) => item.date === formattedFilterDate);
+    }
+
+    // 2단계: 날짜별로 그룹화
     const groupedMap: Record<string, GroupedWearHistoryItem> = {};
 
     filtered.forEach((item) => {
@@ -188,14 +196,8 @@ export default function HistoryScreen() {
 
       if (!groupedMap[key]) {
         groupedMap[key] = {
-          id: key,
-          date: item.date,
-          clothesIds: [...item.clothesIds],
-          historyIds: [item.id],
-          tpoSuitability: item.tpoSuitability || '', 
-          mood: item.mood || '',
-          tpo: item.tpo || '',
-          memo: item.memo || '',
+          id: key, date: item.date, clothesIds: [...item.clothesIds], historyIds: [item.id],
+          tpoSuitability: item.tpoSuitability || '', mood: item.mood || '', tpo: item.tpo || '', memo: item.memo || '',
         };
         return;
       }
@@ -203,22 +205,14 @@ export default function HistoryScreen() {
       groupedMap[key].clothesIds.push(...item.clothesIds);
       groupedMap[key].historyIds.push(item.id);
 
-      if (!groupedMap[key].tpoSuitability && item.tpoSuitability) {
-        groupedMap[key].tpoSuitability = item.tpoSuitability;
-      }
-      if (!groupedMap[key].mood && item.mood) {
-        groupedMap[key].mood = item.mood;
-      }
-      if (!groupedMap[key].tpo && item.tpo) {
-        groupedMap[key].tpo = item.tpo;
-      }
-      if (!groupedMap[key].memo && item.memo) {
-        groupedMap[key].memo = item.memo;
-      }
+      if (!groupedMap[key].tpoSuitability && item.tpoSuitability) groupedMap[key].tpoSuitability = item.tpoSuitability;
+      if (!groupedMap[key].mood && item.mood) groupedMap[key].mood = item.mood;
+      if (!groupedMap[key].tpo && item.tpo) groupedMap[key].tpo = item.tpo;
+      if (!groupedMap[key].memo && item.memo) groupedMap[key].memo = item.memo;
     });
 
     return Object.values(groupedMap).sort((a, b) => b.date.localeCompare(a.date));
-  }, [historyList, selectedFilter]);
+  }, [historyList, selectedFilter, formattedFilterDate]);
 
   const deleteHistoryByApi = async (id: string) => {
     const numericId = Number(id);
@@ -241,9 +235,7 @@ export default function HistoryScreen() {
         onPress: async () => {
           try {
             setDeletingId(group.id);
-            for (const historyId of group.historyIds) {
-              await deleteHistoryByApi(historyId);
-            }
+            for (const historyId of group.historyIds) await deleteHistoryByApi(historyId);
             setHistoryList((prev) => prev.filter((item) => !group.historyIds.includes(item.id)));
           } catch (error) {
             Alert.alert('삭제 실패', error instanceof Error ? error.message : '서버에서 기록을 삭제하지 못했습니다.');
@@ -260,12 +252,8 @@ export default function HistoryScreen() {
     router.push({
       pathname: '/history-detail',
       params: {
-        id: group.id,
-        date: group.date,
-        tpoSuitability: group.tpoSuitability ?? '', 
-        mood: group.mood ?? '',
-        tpo: group.tpo ?? '',
-        memo: group.memo ?? '',
+        id: group.id, date: group.date, tpoSuitability: group.tpoSuitability ?? '', 
+        mood: group.mood ?? '', tpo: group.tpo ?? '', memo: group.memo ?? '',
         clothes: JSON.stringify(clothes),
       },
     });
@@ -276,27 +264,20 @@ export default function HistoryScreen() {
     router.push({
       pathname: '/history-create',
       params: {
-        editMode: 'true',
-        editId: group.id,
-        editDate: group.date,
-        editMemo: group.memo ?? '',
-        editTpo: group.tpo ?? '',
-        editTpoSuitability: group.tpoSuitability ?? '', 
-        editTemperature: group.mood ?? '',
-        editClothes: JSON.stringify(clothes),
+        editMode: 'true', editId: group.id, editDate: group.date, editMemo: group.memo ?? '',
+        editTpo: group.tpo ?? '', editTpoSuitability: group.tpoSuitability ?? '', 
+        editTemperature: group.mood ?? '', clothes: JSON.stringify(clothes),
         editHistoryIds: JSON.stringify(group.historyIds),
       },
     });
   };
 
-  const handleCreatePress = () => {
-    router.push('/history-create');
-  };
+  const handleCreatePress = () => router.push('/history-create');
 
   const EmptyState = () => (
     <View style={styles.emptyContainer}>
       <Text style={styles.emptyTitle}>해당 조건의 착용 기록이 없습니다</Text>
-      <Text style={styles.emptyDescription}>다른 필터를 선택하거나 새 기록을 추가해보세요.</Text>
+      <Text style={styles.emptyDescription}>다른 필터나 날짜를 선택해보세요.</Text>
     </View>
   );
 
@@ -315,9 +296,7 @@ export default function HistoryScreen() {
         <Text style={styles.emptyTitle}>기록을 불러오지 못했습니다</Text>
         <Text style={styles.emptyDescription}>{errorMessage}</Text>
         <View style={styles.errorButtonRow}>
-          <Pressable style={styles.actionButton} onPress={() => fetchHistoryList()}>
-            <Text style={styles.actionButtonText}>다시 시도</Text>
-          </Pressable>
+          <Pressable style={styles.actionButton} onPress={() => fetchHistoryList()}><Text style={styles.actionButtonText}>다시 시도</Text></Pressable>
         </View>
       </SafeAreaView>
     );
@@ -325,9 +304,39 @@ export default function HistoryScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
+      {/* ✨ 헤더 영역 (날짜 선택 버튼 및 선택된 날짜 뱃지 추가) */}
       <View style={styles.header}>
-        <Text style={styles.title}>착용 기록</Text>
+        <View>
+          <Text style={styles.title}>착용 기록</Text>
+          {filterDate && (
+            <View style={styles.activeDateBadge}>
+              <Text style={styles.activeDateText}>{formattedFilterDate?.replace(/-/g, '. ')}</Text>
+              <Pressable onPress={() => setFilterDate(null)} hitSlop={10} style={styles.clearDateIcon}>
+                <Ionicons name="close-circle" size={16} color="#4F46E5" />
+              </Pressable>
+            </View>
+          )}
+        </View>
+        <Pressable style={styles.calendarButton} onPress={() => setShowDatePicker(true)}>
+          <Ionicons name="calendar" size={26} color="#111" />
+        </Pressable>
       </View>
+
+      {/* DatePicker 달력 팝업 렌더링 */}
+      {showDatePicker && (
+        <DateTimePicker
+          value={filterDate || new Date()}
+          mode="date"
+          display="default"
+          onChange={handleDateChange}
+        />
+      )}
+      
+      {showDatePicker && Platform.OS === 'ios' && (
+        <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}>
+          <Text style={styles.iosDatePickerDoneText}>닫기</Text>
+        </Pressable>
+      )}
 
       <View>
         <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.filterScroll}>
@@ -346,75 +355,47 @@ export default function HistoryScreen() {
         data={groupedHistoryData}
         keyExtractor={(item) => item.id}
         renderItem={({ item }) => {
-          // ✨ 카테고리 순서(아우터 > 상의 > 하의 > 신발 > 악세사리 > 기타)대로 정렬
           const clothes = getClothesByIds(item.clothesIds).sort((a, b) => {
             const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
             return (order[a.category] || 99) - (order[b.category] || 99);
           });
-          
           const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
           
           let displayDate = item.date;
           if (item.date) {
             const dateObj = new Date(item.date);
             const days = ['일', '월', '화', '수', '목', '금', '토'];
-            const dayOfWeek = days[dateObj.getDay()];
-            displayDate = `${item.date.replace(/-/g, '. ')} (${dayOfWeek})`;
+            displayDate = `${item.date.replace(/-/g, '. ')} (${days[dateObj.getDay()]})`;
           }
 
           return (
             <View style={styles.card}>
               <Text style={styles.date}>{displayDate}</Text>
-
-              {/* 1. 카테고리를 위로 올리고, 사진 잘림(Crop) 현상을 해결한 스크롤 영역 */}
               <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>
                 {clothes.length > 0 ? (
                   clothes.map((cloth) => (
                     <View key={cloth.id} style={styles.clothThumbnailBox}>
-                      {/* 카테고리를 사진 위로 배치 */}
                       <Text style={styles.clothCategory}>{cloth.category}</Text>
-                      
-                      {/* 사진이 잘리지 않도록 래퍼로 감싸고 resizeMode="contain" 적용 */}
                       <View style={styles.imageWrapper}>
-                        <Image 
-                          source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
-                          style={styles.clothThumbnailImage} 
-                          resizeMode="contain" 
-                        />
+                        <Image source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothThumbnailImage} resizeMode="contain" />
                       </View>
-                      
                       <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
                     </View>
                   ))
                 ) : (
-                  <View style={styles.clothBox}>
-                    <Text style={styles.clothName}>옷 정보 없음</Text>
-                  </View>
+                  <View style={styles.clothBox}><Text style={styles.clothName}>옷 정보 없음</Text></View>
                 )}
               </ScrollView>
 
-              {/* 2. 태그와 메모를 은은한 회색 박스로 묶고 아이콘 추가 */}
               <View style={styles.metaContainer}>
-                <View style={styles.metaRow}>
-                  <Ionicons name="pricetag" size={14} color="#3B82F6" />
-                  <Text style={styles.tagsText}>{tagText}</Text>
-                </View>
-                <View style={styles.metaRow}>
-                  <Ionicons name="chatbubble-ellipses" size={14} color="#10B981" />
-                  <Text style={styles.memoText}>{item.memo || '메모 없음'}</Text>
-                </View>
+                <View style={styles.metaRow}><Ionicons name="pricetag" size={14} color="#3B82F6" /><Text style={styles.tagsText}>{tagText}</Text></View>
+                <View style={styles.metaRow}><Ionicons name="chatbubble-ellipses" size={14} color="#10B981" /><Text style={styles.memoText}>{item.memo || '메모 없음'}</Text></View>
               </View>
 
               <View style={styles.actionRow}>
-                <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}>
-                  <Text style={styles.actionButtonText}>상세보기</Text>
-                </Pressable>
-                <Pressable style={styles.actionButton} onPress={() => handleEditPress(item)} disabled={deletingId === item.id}>
-                  <Text style={styles.actionButtonText}>수정</Text>
-                </Pressable>
-                <Pressable style={[styles.actionButton, styles.deleteButton]} onPress={() => handleDelete(item)} disabled={deletingId === item.id}>
-                  <Text style={[styles.actionButtonText, styles.deleteButtonText]}>{deletingId === item.id ? '삭제 중...' : '삭제'}</Text>
-                </Pressable>
+                <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}><Text style={styles.actionButtonText}>상세보기</Text></Pressable>
+                <Pressable style={styles.actionButton} onPress={() => handleEditPress(item)} disabled={deletingId === item.id}><Text style={styles.actionButtonText}>수정</Text></Pressable>
+                <Pressable style={[styles.actionButton, styles.deleteButton]} onPress={() => handleDelete(item)} disabled={deletingId === item.id}><Text style={[styles.actionButtonText, styles.deleteButtonText]}>{deletingId === item.id ? '삭제 중...' : '삭제'}</Text></Pressable>
               </View>
             </View>
           );
@@ -426,7 +407,6 @@ export default function HistoryScreen() {
         showsVerticalScrollIndicator={false}
       />
 
-      {/* 우측 하단 플로팅 액션 버튼 (FAB) */}
       <Pressable style={styles.fab} onPress={handleCreatePress}>
         <Ionicons name="add" size={28} color="#fff" />
       </Pressable>
@@ -436,79 +416,54 @@ export default function HistoryScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff', paddingHorizontal: 16, paddingTop: 16 },
-  header: { marginBottom: 12, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  title: { fontSize: 28, fontWeight: '700', color: '#111' },
+  header: { marginBottom: 16, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
+  title: { fontSize: 28, fontWeight: '800', color: '#111' },
   
+  // ✨ 날짜 필터 뱃지 및 아이콘 스타일
+  calendarButton: { padding: 4 },
+  activeDateBadge: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#EEF2FF', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 16, marginTop: 6, alignSelf: 'flex-start', borderWidth: 1, borderColor: '#C7D2FE' },
+  activeDateText: { fontSize: 13, fontWeight: '700', color: '#4F46E5' },
+  clearDateIcon: { marginLeft: 6 },
+  
+  iosDatePickerDone: { alignItems: 'center', backgroundColor: '#E2E8F0', padding: 12, borderRadius: 8, marginBottom: 16 },
+  iosDatePickerDoneText: { fontSize: 15, fontWeight: '700', color: '#1E293B' },
+
   filterScroll: { gap: 8, paddingBottom: 16 },
-  filterChip: { backgroundColor: '#f1f1f1', borderRadius: 999, paddingHorizontal: 12, paddingVertical: 8 },
-  filterChipSelected: { backgroundColor: '#111' },
-  filterChipText: { fontSize: 13, color: '#333', fontWeight: '500' },
+  filterChip: { backgroundColor: '#F1F5F9', borderRadius: 999, paddingHorizontal: 14, paddingVertical: 8, borderWidth: 1, borderColor: '#E2E8F0' },
+  filterChipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
+  filterChipText: { fontSize: 13, color: '#475569', fontWeight: '600' },
   filterChipTextSelected: { color: '#fff' },
   
   listContent: { paddingBottom: 24 },
   emptyListContent: { flexGrow: 1 },
-  card: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
-  date: { fontSize: 16, fontWeight: '700', color: '#111', marginBottom: 10 },
+  card: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 14, borderWidth: 1, borderColor: '#E2E8F0', shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.03, shadowRadius: 8, elevation: 2 },
+  date: { fontSize: 16, fontWeight: '800', color: '#1E293B', marginBottom: 14 },
   
-  // 옷 이미지 썸네일 관련 스타일 모음
   clothesScroll: { gap: 14, paddingBottom: 12 },
-  clothThumbnailBox: { width: 110, alignItems: 'center' },
-  clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 6 },
-  imageWrapper: { 
-    width: 110, 
-    height: 110, 
-    backgroundColor: '#F1F5F9', 
-    borderRadius: 12, 
-    marginBottom: 8, 
-    overflow: 'hidden',
-    justifyContent: 'center',
-    alignItems: 'center'
-  },
+  clothThumbnailBox: { width: 100, alignItems: 'center' },
+  clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 8 },
+  imageWrapper: { width: 100, height: 100, backgroundColor: '#F8FAFC', borderRadius: 12, marginBottom: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#F1F5F9' },
   clothThumbnailImage: { width: '90%', height: '90%' }, 
-  clothName: { fontSize: 13, fontWeight: '600', color: '#1E293B', textAlign: 'center' },
+  clothName: { fontSize: 13, fontWeight: '700', color: '#334155', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
   
-  // 태그/메모 스타일
-  metaContainer: { 
-    backgroundColor: '#F8FAFC', 
-    padding: 12, 
-    borderRadius: 12, 
-    gap: 8, 
-    marginBottom: 12,
-    borderWidth: 1,
-    borderColor: '#F1F5F9'
-  },
+  metaContainer: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, gap: 8, marginBottom: 12, borderWidth: 1, borderColor: '#F1F5F9' },
   metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   tagsText: { fontSize: 13, fontWeight: '700', color: '#334155' },
   memoText: { fontSize: 13, color: '#475569', lineHeight: 20 },
   
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 12 },
-  actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#ddd', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },
-  actionButtonText: { fontSize: 13, fontWeight: '600', color: '#333' },
-  deleteButton: { borderColor: '#f0caca' },
-  deleteButtonText: { color: '#c0392b' },
+  actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },
+  actionButtonText: { fontSize: 13, fontWeight: '700', color: '#475569' },
+  deleteButton: { borderColor: '#FECACA' },
+  deleteButtonText: { color: '#EF4444' },
   
   emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
-  emptyTitle: { fontSize: 18, fontWeight: '700', color: '#222', marginBottom: 8, textAlign: 'center' },
-  emptyDescription: { fontSize: 14, color: '#777', textAlign: 'center' },
+  emptyTitle: { fontSize: 17, fontWeight: '800', color: '#1E293B', marginBottom: 8, textAlign: 'center' },
+  emptyDescription: { fontSize: 14, color: '#64748B', textAlign: 'center' },
   
   loadingContainer: { flex: 1, backgroundColor: '#fff', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
   errorButtonRow: { flexDirection: 'row', gap: 8, marginTop: 16 },
 
-  fab: { 
-    position: 'absolute', 
-    bottom: 24, 
-    right: 24, 
-    width: 56, 
-    height: 56, 
-    backgroundColor: '#111', 
-    borderRadius: 28, 
-    justifyContent: 'center', 
-    alignItems: 'center', 
-    shadowColor: '#000', 
-    shadowOffset: { width: 0, height: 4 }, 
-    shadowOpacity: 0.3, 
-    shadowRadius: 4, 
-    elevation: 5 
-  },
+  fab: { position: 'absolute', bottom: 24, right: 24, width: 56, height: 56, backgroundColor: '#111', borderRadius: 28, justifyContent: 'center', alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.3, shadowRadius: 4, elevation: 5 },
 });

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -352,16 +352,23 @@ export default function HistoryScreen() {
             <View style={styles.card}>
               <Text style={styles.date}>{item.date}</Text>
 
+              {/* ✨ 1. 카테고리를 위로 올리고, 사진 잘림(Crop) 현상을 해결한 스크롤 영역 */}
               <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>
                 {clothes.length > 0 ? (
                   clothes.map((cloth) => (
                     <View key={cloth.id} style={styles.clothThumbnailBox}>
-                      <Image 
-                        source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
-                        style={styles.clothThumbnailImage} 
-                        resizeMode="cover"
-                      />
+                      {/* 카테고리를 사진 위로 배치 */}
                       <Text style={styles.clothCategory}>{cloth.category}</Text>
+                      
+                      {/* 사진이 잘리지 않도록 래퍼로 감싸고 resizeMode="contain" 적용 */}
+                      <View style={styles.imageWrapper}>
+                        <Image 
+                          source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
+                          style={styles.clothThumbnailImage} 
+                          resizeMode="contain" 
+                        />
+                      </View>
+                      
                       <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
                     </View>
                   ))
@@ -372,8 +379,17 @@ export default function HistoryScreen() {
                 )}
               </ScrollView>
 
-              <Text style={styles.tags}>{tagText}</Text>
-              <Text style={styles.memo}>{item.memo || '메모 없음'}</Text>
+              {/* ✨ 2. 태그와 메모를 은은한 회색 박스로 묶고 아이콘 추가 */}
+              <View style={styles.metaContainer}>
+                <View style={styles.metaRow}>
+                  <Ionicons name="pricetag" size={14} color="#3B82F6" />
+                  <Text style={styles.tagsText}>{tagText}</Text>
+                </View>
+                <View style={styles.metaRow}>
+                  <Ionicons name="chatbubble-ellipses" size={14} color="#10B981" />
+                  <Text style={styles.memoText}>{item.memo || '메모 없음'}</Text>
+                </View>
+              </View>
 
               <View style={styles.actionRow}>
                 <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}>
@@ -420,21 +436,37 @@ const styles = StyleSheet.create({
   card: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
   date: { fontSize: 16, fontWeight: '700', color: '#111', marginBottom: 10 },
   
-  clothesScroll: { gap: 14, paddingBottom: 12 }, // 사진이 커진 만큼 카드 사이 간격도 12 -> 14로 여유 있게
-  clothThumbnailBox: { width: 100, alignItems: 'center' }, // 너비 80 -> 100으로 확대
-  clothThumbnailImage: { 
-    width: 100, 
-    height: 100, // 높이도 80 -> 100으로 확대하여 큼직하게!
+  // ✨ 옷 이미지 썸네일 관련 스타일 모음
+  clothesScroll: { gap: 14, paddingBottom: 12 },
+  clothThumbnailBox: { width: 110, alignItems: 'center' },
+  clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 6 },
+  imageWrapper: { 
+    width: 110, 
+    height: 110, 
+    backgroundColor: '#F1F5F9', 
     borderRadius: 12, 
-    backgroundColor: '#eaeaea', 
-    marginBottom: 8 
+    marginBottom: 8, 
+    overflow: 'hidden',
+    justifyContent: 'center',
+    alignItems: 'center'
   },
-  clothCategory: { fontSize: 12, color: '#888', marginBottom: 4 }, // 글씨도 11 -> 12로 살짝 키움
-  clothName: { fontSize: 13, fontWeight: '600', color: '#222', textAlign: 'center' }, // 글씨 12 -> 13으로 키움
+  clothThumbnailImage: { width: '90%', height: '90%' }, 
+  clothName: { fontSize: 13, fontWeight: '600', color: '#1E293B', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
   
-  tags: { fontSize: 14, color: '#444', marginBottom: 6 },
-  memo: { fontSize: 14, color: '#666' },
+  // ✨ 태그/메모 스타일
+  metaContainer: { 
+    backgroundColor: '#F8FAFC', 
+    padding: 12, 
+    borderRadius: 12, 
+    gap: 8, 
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: '#F1F5F9'
+  },
+  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  tagsText: { fontSize: 13, fontWeight: '700', color: '#334155' },
+  memoText: { fontSize: 13, color: '#475569', lineHeight: 20 },
   
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 12 },
   actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#ddd', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -221,7 +221,10 @@ export default function HistoryScreen() {
             const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
             return (order[a.category] || 99) - (order[b.category] || 99);
           });
-          const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
+          
+          // ✨ 개별 태그 배열 생성
+          const tags = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '');
+          
           let displayDate = item.date;
           if (item.date) {
             const days = ['일', '월', '화', '수', '목', '금', '토'];
@@ -230,7 +233,25 @@ export default function HistoryScreen() {
 
           return (
             <View style={styles.card}>
-              <Text style={styles.date}>{displayDate}</Text>
+              <View style={styles.cardHeader}>
+                <Text style={styles.date}>{displayDate}</Text>
+                
+                {/* ✨ 쪼개진 태그 렌더링 */}
+                <View style={styles.tagWrapper}>
+                  {tags.length > 0 ? (
+                    tags.map((tag, index) => (
+                      <View key={index} style={styles.headerTagBadge}>
+                        <Text style={styles.headerTagText}>{tag}</Text>
+                      </View>
+                    ))
+                  ) : (
+                    <View style={styles.headerTagBadge}>
+                      <Text style={styles.headerTagText}>태그 없음</Text>
+                    </View>
+                  )}
+                </View>
+              </View>
+
               <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>
                 {clothes.length > 0 ? (
                   clothes.map((cloth) => (
@@ -243,10 +264,13 @@ export default function HistoryScreen() {
                 ) : (<View style={styles.clothBox}><Text style={styles.clothName}>옷 정보 없음</Text></View>)}
               </ScrollView>
 
-              <View style={styles.metaContainer}>
-                <View style={styles.metaRow}><Ionicons name="pricetag" size={14} color="#3B82F6" /><Text style={styles.tagsText}>{tagText}</Text></View>
-                <View style={styles.metaRow}><Ionicons name="chatbubble-ellipses" size={14} color="#10B981" /><Text style={styles.memoText}>{item.memo || '메모 없음'}</Text></View>
-              </View>
+              {/* ✨ 인용구 스타일의 메모 영역 */}
+              {item.memo && item.memo.trim() !== '' && (
+                <View style={styles.memoBox}>
+                  <Ionicons name="pencil" size={14} color="#4F46E5" style={{ marginTop: 2 }} />
+                  <Text style={styles.memoText} numberOfLines={2}>{item.memo}</Text>
+                </View>
+              )}
 
               <View style={styles.actionRow}>
                 <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}><Text style={styles.actionButtonText}>상세보기</Text></Pressable>
@@ -280,8 +304,16 @@ const styles = StyleSheet.create({
   filterChipTextSelected: { color: '#fff' },
   listContent: { paddingBottom: 24 },
   emptyListContent: { flexGrow: 1 },
+  
   card: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 14, borderWidth: 1, borderColor: '#E2E8F0', shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.03, shadowRadius: 8, elevation: 2 },
-  date: { fontSize: 16, fontWeight: '800', color: '#1E293B', marginBottom: 14 },
+  
+  // ✨ 카드 헤더 및 쪼개진 태그 스타일
+  cardHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 },
+  date: { fontSize: 16, fontWeight: '800', color: '#1E293B' },
+  tagWrapper: { flexDirection: 'row', gap: 6, flexWrap: 'wrap', flex: 1, justifyContent: 'flex-end', marginLeft: 12 },
+  headerTagBadge: { backgroundColor: '#EEF2FF', paddingHorizontal: 8, paddingVertical: 4, borderRadius: 6 },
+  headerTagText: { fontSize: 12, fontWeight: '700', color: '#4F46E5' },
+  
   clothesScroll: { gap: 14, paddingBottom: 12 },
   clothThumbnailBox: { width: 100, alignItems: 'center' },
   clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 8 },
@@ -289,10 +321,11 @@ const styles = StyleSheet.create({
   clothThumbnailImage: { width: '90%', height: '90%' }, 
   clothName: { fontSize: 13, fontWeight: '700', color: '#334155', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
-  metaContainer: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, gap: 8, marginBottom: 12, borderWidth: 1, borderColor: '#F1F5F9' },
-  metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
-  tagsText: { fontSize: 13, fontWeight: '700', color: '#334155' },
-  memoText: { fontSize: 13, color: '#475569', lineHeight: 20 },
+  
+  // ✨ 왼쪽 띠를 적용한 감성적인 메모 박스 스타일
+  memoBox: { flexDirection: 'row', alignItems: 'flex-start', backgroundColor: '#F8FAFC', paddingVertical: 10, paddingHorizontal: 12, borderRadius: 8, gap: 8, marginTop: 8, borderLeftWidth: 3, borderLeftColor: '#4F46E5' },
+  memoText: { fontSize: 13, color: '#334155', fontWeight: '500', lineHeight: 20, flex: 1 },
+  
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 12 },
   actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },
   actionButtonText: { fontSize: 13, fontWeight: '700', color: '#475569' },

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -347,10 +347,18 @@ export default function HistoryScreen() {
         renderItem={({ item }) => {
           const clothes = getClothesByIds(item.clothesIds);
           const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
+          
+          let displayDate = item.date;
+          if (item.date) {
+            const dateObj = new Date(item.date);
+            const days = ['일', '월', '화', '수', '목', '금', '토'];
+            const dayOfWeek = days[dateObj.getDay()];
+            displayDate = `${item.date.replace(/-/g, '. ')} (${dayOfWeek})`;
+          }
 
           return (
             <View style={styles.card}>
-              <Text style={styles.date}>{item.date}</Text>
+              <Text style={styles.date}>{displayDate}</Text>
 
               {/* ✨ 1. 카테고리를 위로 올리고, 사진 잘림(Crop) 현상을 해결한 스크롤 영역 */}
               <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -284,6 +284,7 @@ export default function HistoryScreen() {
         editTpoSuitability: group.tpoSuitability ?? '', 
         editTemperature: group.mood ?? '',
         editClothes: JSON.stringify(clothes),
+        editHistoryIds: JSON.stringify(group.historyIds),
       },
     });
   };

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -1,14 +1,17 @@
+import { Ionicons } from '@expo/vector-icons';
 import { router, useFocusEffect } from 'expo-router';
 import { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   FlatList,
+  Image,
   Pressable,
   SafeAreaView,
+  ScrollView,
   StyleSheet,
   Text,
-  View,
+  View
 } from 'react-native';
 
 import api from '../_api';
@@ -18,7 +21,7 @@ type ClothingItem = {
   name: string;
   category: string;
   color?: string;
-  imageUrl?: string; // ✅ 상세 화면으로 보낼 이미지 URL 타입 추가
+  imageUrl?: string;
 };
 
 type WearHistoryItem = {
@@ -47,7 +50,7 @@ type HistoryApiItem = {
     name?: string;
     category?: string;
     color?: string;
-    image_url?: string; // ✅ 백엔드에서 받아올 이미지 필드 추가
+    image_url?: string;
     tags?: {
       category?: string;
       color?: string;
@@ -145,7 +148,7 @@ export default function HistoryScreen() {
           name: item.clothes?.name ?? `옷 ${clothesId}`,
           category: category,
           color: color,
-          imageUrl: fullImageUrl, // ✅ 변환된 절대 경로 저장
+          imageUrl: fullImageUrl,
         };
       });
 
@@ -289,61 +292,10 @@ export default function HistoryScreen() {
     router.push('/history-create');
   };
 
-  const renderItem = ({ item }: { item: GroupedWearHistoryItem }) => {
-    const clothes = getClothesByIds(item.clothesIds);
-
-    const tagText =
-      [item.tpo, item.tpoSuitability, item.mood]
-        .filter((value) => value && value.trim() !== '')
-        .join(' · ') || '태그 없음';
-
-    return (
-      <View style={styles.card}>
-        <Text style={styles.date}>{item.date}</Text>
-
-        <View style={styles.clothesColumn}>
-          {clothes.length > 0 ? (
-            clothes.map((cloth) => (
-              <View key={cloth.id} style={styles.clothBox}>
-                <Text style={styles.clothCategory}>{cloth.category}</Text>
-                <Text style={styles.clothName}>{cloth.name}</Text>
-              </View>
-            ))
-          ) : (
-            <View style={styles.clothBox}>
-              <Text style={styles.clothCategory}>옷 정보</Text>
-              <Text style={styles.clothName}>표시할 옷 정보 없음</Text>
-            </View>
-          )}
-        </View>
-
-        <Text style={styles.tags}>{tagText}</Text>
-        <Text style={styles.memo}>{item.memo || '메모 없음'}</Text>
-
-        <View style={styles.actionRow}>
-          <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}>
-            <Text style={styles.actionButtonText}>상세보기</Text>
-          </Pressable>
-          <Pressable style={styles.actionButton} onPress={() => handleEditPress(item)} disabled={deletingId === item.id}>
-            <Text style={styles.actionButtonText}>수정</Text>
-          </Pressable>
-          <Pressable style={[styles.actionButton, styles.deleteButton]} onPress={() => handleDelete(item)} disabled={deletingId === item.id}>
-            <Text style={[styles.actionButtonText, styles.deleteButtonText]}>
-              {deletingId === item.id ? '삭제 중...' : '삭제'}
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-    );
-  };
-
   const EmptyState = () => (
     <View style={styles.emptyContainer}>
       <Text style={styles.emptyTitle}>해당 조건의 착용 기록이 없습니다</Text>
       <Text style={styles.emptyDescription}>다른 필터를 선택하거나 새 기록을 추가해보세요.</Text>
-      <Pressable style={styles.emptyAddButton} onPress={handleCreatePress}>
-        <Text style={styles.emptyAddButtonText}>기록 추가</Text>
-      </Pressable>
     </View>
   );
 
@@ -365,9 +317,6 @@ export default function HistoryScreen() {
           <Pressable style={styles.actionButton} onPress={() => fetchHistoryList()}>
             <Text style={styles.actionButtonText}>다시 시도</Text>
           </Pressable>
-          <Pressable style={[styles.actionButton, styles.headerAddButton]} onPress={handleCreatePress}>
-            <Text style={[styles.actionButtonText, styles.headerAddButtonText]}>기록 추가</Text>
-          </Pressable>
         </View>
       </SafeAreaView>
     );
@@ -377,32 +326,80 @@ export default function HistoryScreen() {
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
         <Text style={styles.title}>착용 기록</Text>
-        <Pressable style={styles.headerAddButton} onPress={handleCreatePress}>
-          <Text style={styles.headerAddButtonText}>기록 추가</Text>
-        </Pressable>
       </View>
 
-      <View style={styles.filterRow}>
-        {filterOptions.map((filter) => {
-          const isSelected = selectedFilter === filter;
-          return (
-            <Pressable key={filter} style={[styles.filterChip, isSelected && styles.filterChipSelected]} onPress={() => setSelectedFilter(filter)}>
-              <Text style={[styles.filterChipText, isSelected && styles.filterChipTextSelected]}>{filter}</Text>
-            </Pressable>
-          );
-        })}
+      <View>
+        <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.filterScroll}>
+          {filterOptions.map((filter) => {
+            const isSelected = selectedFilter === filter;
+            return (
+              <Pressable key={filter} style={[styles.filterChip, isSelected && styles.filterChipSelected]} onPress={() => setSelectedFilter(filter)}>
+                <Text style={[styles.filterChipText, isSelected && styles.filterChipTextSelected]}>{filter}</Text>
+              </Pressable>
+            );
+          })}
+        </ScrollView>
       </View>
 
       <FlatList
         data={groupedHistoryData}
         keyExtractor={(item) => item.id}
-        renderItem={renderItem}
+        renderItem={({ item }) => {
+          const clothes = getClothesByIds(item.clothesIds);
+          const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
+
+          return (
+            <View style={styles.card}>
+              <Text style={styles.date}>{item.date}</Text>
+
+              <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothesScroll}>
+                {clothes.length > 0 ? (
+                  clothes.map((cloth) => (
+                    <View key={cloth.id} style={styles.clothThumbnailBox}>
+                      <Image 
+                        source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
+                        style={styles.clothThumbnailImage} 
+                        resizeMode="cover"
+                      />
+                      <Text style={styles.clothCategory}>{cloth.category}</Text>
+                      <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
+                    </View>
+                  ))
+                ) : (
+                  <View style={styles.clothBox}>
+                    <Text style={styles.clothName}>옷 정보 없음</Text>
+                  </View>
+                )}
+              </ScrollView>
+
+              <Text style={styles.tags}>{tagText}</Text>
+              <Text style={styles.memo}>{item.memo || '메모 없음'}</Text>
+
+              <View style={styles.actionRow}>
+                <Pressable style={styles.actionButton} onPress={() => handleDetailPress(item)} disabled={deletingId === item.id}>
+                  <Text style={styles.actionButtonText}>상세보기</Text>
+                </Pressable>
+                <Pressable style={styles.actionButton} onPress={() => handleEditPress(item)} disabled={deletingId === item.id}>
+                  <Text style={styles.actionButtonText}>수정</Text>
+                </Pressable>
+                <Pressable style={[styles.actionButton, styles.deleteButton]} onPress={() => handleDelete(item)} disabled={deletingId === item.id}>
+                  <Text style={[styles.actionButtonText, styles.deleteButtonText]}>{deletingId === item.id ? '삭제 중...' : '삭제'}</Text>
+                </Pressable>
+              </View>
+            </View>
+          );
+        }}
         onRefresh={() => fetchHistoryList(true)}
         refreshing={refreshing}
         contentContainerStyle={[styles.listContent, groupedHistoryData.length === 0 && styles.emptyListContent]}
         ListEmptyComponent={<EmptyState />}
         showsVerticalScrollIndicator={false}
       />
+
+      {/* 우측 하단 플로팅 액션 버튼 (FAB) */}
+      <Pressable style={styles.fab} onPress={handleCreatePress}>
+        <Ionicons name="add" size={28} color="#fff" />
+      </Pressable>
     </SafeAreaView>
   );
 }
@@ -411,33 +408,61 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff', paddingHorizontal: 16, paddingTop: 16 },
   header: { marginBottom: 12, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
   title: { fontSize: 28, fontWeight: '700', color: '#111' },
-  headerAddButton: { backgroundColor: '#111', borderRadius: 10, paddingHorizontal: 14, paddingVertical: 9 },
-  headerAddButtonText: { color: '#fff', fontSize: 13, fontWeight: '700' },
-  filterRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
+  
+  filterScroll: { gap: 8, paddingBottom: 16 },
   filterChip: { backgroundColor: '#f1f1f1', borderRadius: 999, paddingHorizontal: 12, paddingVertical: 8 },
   filterChipSelected: { backgroundColor: '#111' },
   filterChipText: { fontSize: 13, color: '#333', fontWeight: '500' },
   filterChipTextSelected: { color: '#fff' },
+  
   listContent: { paddingBottom: 24 },
   emptyListContent: { flexGrow: 1 },
   card: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
   date: { fontSize: 16, fontWeight: '700', color: '#111', marginBottom: 10 },
-  clothesColumn: { gap: 8, marginBottom: 10 },
+  
+  clothesScroll: { gap: 14, paddingBottom: 12 }, // 사진이 커진 만큼 카드 사이 간격도 12 -> 14로 여유 있게
+  clothThumbnailBox: { width: 100, alignItems: 'center' }, // 너비 80 -> 100으로 확대
+  clothThumbnailImage: { 
+    width: 100, 
+    height: 100, // 높이도 80 -> 100으로 확대하여 큼직하게!
+    borderRadius: 12, 
+    backgroundColor: '#eaeaea', 
+    marginBottom: 8 
+  },
+  clothCategory: { fontSize: 12, color: '#888', marginBottom: 4 }, // 글씨도 11 -> 12로 살짝 키움
+  clothName: { fontSize: 13, fontWeight: '600', color: '#222', textAlign: 'center' }, // 글씨 12 -> 13으로 키움
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
-  clothCategory: { fontSize: 12, color: '#888', marginBottom: 4 },
-  clothName: { fontSize: 13, fontWeight: '600', color: '#222' },
+  
   tags: { fontSize: 14, color: '#444', marginBottom: 6 },
   memo: { fontSize: 14, color: '#666' },
+  
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 12 },
   actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#ddd', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },
   actionButtonText: { fontSize: 13, fontWeight: '600', color: '#333' },
   deleteButton: { borderColor: '#f0caca' },
   deleteButtonText: { color: '#c0392b' },
+  
   emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   emptyTitle: { fontSize: 18, fontWeight: '700', color: '#222', marginBottom: 8, textAlign: 'center' },
   emptyDescription: { fontSize: 14, color: '#777', textAlign: 'center' },
-  emptyAddButton: { marginTop: 16, backgroundColor: '#111', borderRadius: 10, paddingHorizontal: 16, paddingVertical: 10 },
-  emptyAddButtonText: { color: '#fff', fontSize: 14, fontWeight: '700' },
+  
   loadingContainer: { flex: 1, backgroundColor: '#fff', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
   errorButtonRow: { flexDirection: 'row', gap: 8, marginTop: 16 },
+
+  fab: { 
+    position: 'absolute', 
+    bottom: 24, 
+    right: 24, 
+    width: 56, 
+    height: 56, 
+    backgroundColor: '#111', 
+    borderRadius: 28, 
+    justifyContent: 'center', 
+    alignItems: 'center', 
+    shadowColor: '#000', 
+    shadowOffset: { width: 0, height: 4 }, 
+    shadowOpacity: 0.3, 
+    shadowRadius: 4, 
+    elevation: 5 
+  },
 });

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -18,59 +18,10 @@ import {
 
 import api from '../_api';
 
-type ClothingItem = {
-  id: string;
-  name: string;
-  category: string;
-  color?: string;
-  imageUrl?: string;
-};
-
-type WearHistoryItem = {
-  id: string;
-  date: string;
-  clothesIds: string[];
-  tpoSuitability?: string; 
-  mood?: string;
-  tpo?: string;
-  memo?: string;
-};
-
-type HistoryApiItem = {
-  history_id: number;
-  clothes_id?: number;
-  worn_date?: string;
-  style?: string;
-  mood?: string;
-  tpo?: string;
-  memo?: string;
-  feedback_fit?: string;
-  feedback_temperature?: string;
-  feedback_tpo?: string;
-  clothes?: {
-    clothes_id?: number;
-    name?: string;
-    category?: string;
-    color?: string;
-    image_url?: string;
-    tags?: {
-      category?: string;
-      color?: string;
-      [key: string]: any;
-    };
-  };
-};
-
-type GroupedWearHistoryItem = {
-  id: string;
-  date: string;
-  clothesIds: string[];
-  historyIds: string[];
-  tpoSuitability?: string; 
-  mood?: string;
-  tpo?: string;
-  memo?: string;
-};
+type ClothingItem = { id: string; name: string; category: string; color?: string; imageUrl?: string; };
+type WearHistoryItem = { id: string; date: string; clothesIds: string[]; tpoSuitability?: string; mood?: string; tpo?: string; memo?: string; };
+type HistoryApiItem = { history_id: number; clothes_id?: number; worn_date?: string; style?: string; mood?: string; tpo?: string; memo?: string; feedback_fit?: string; feedback_temperature?: string; feedback_tpo?: string; clothes?: { clothes_id?: number; name?: string; category?: string; color?: string; image_url?: string; tags?: { category?: string; color?: string; [key: string]: any; }; }; };
+type GroupedWearHistoryItem = { id: string; date: string; clothesIds: string[]; historyIds: string[]; tpoSuitability?: string; mood?: string; tpo?: string; memo?: string; };
 
 const filterOptions = ['전체', '데일리', '비즈니스', '면접', '결혼식', '장례식', '운동', '데이트', '모임', '여행'];
 
@@ -80,26 +31,16 @@ function formatDate(dateString?: string) {
 }
 
 function mapApiHistoryToUi(item: HistoryApiItem): WearHistoryItem {
-  const clothesId =
-    item.clothes?.clothes_id?.toString() ??
-    item.clothes_id?.toString() ??
-    '';
-
+  const clothesId = item.clothes?.clothes_id?.toString() ?? item.clothes_id?.toString() ?? '';
   return {
-    id: item.history_id.toString(),
-    date: formatDate(item.worn_date),
-    clothesIds: clothesId ? [clothesId] : [],
-    tpoSuitability: item.feedback_tpo ?? item.style ?? '', 
-    mood: item.feedback_temperature ?? item.mood ?? '',
-    tpo: item.tpo ?? '',
-    memo: item.memo ?? '',
+    id: item.history_id.toString(), date: formatDate(item.worn_date), clothesIds: clothesId ? [clothesId] : [],
+    tpoSuitability: item.feedback_tpo ?? item.style ?? '', mood: item.feedback_temperature ?? item.mood ?? '',
+    tpo: item.tpo ?? '', memo: item.memo ?? '',
   };
 }
 
 export default function HistoryScreen() {
   const [selectedFilter, setSelectedFilter] = useState('전체');
-  
-  // ✨ 날짜 필터링 상태 추가
   const [filterDate, setFilterDate] = useState<Date | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);
   
@@ -112,9 +53,7 @@ export default function HistoryScreen() {
 
   const getClothesByIds = (ids: string[]) => {
     const uniqueIds = Array.from(new Set(ids));
-    return uniqueIds
-      .map((id) => clothesMap[id])
-      .filter(Boolean) as ClothingItem[];
+    return uniqueIds.map((id) => clothesMap[id]).filter(Boolean) as ClothingItem[];
   };
 
   const fetchHistoryList = useCallback(async (isRefresh = false) => {
@@ -137,8 +76,7 @@ export default function HistoryScreen() {
         const fullImageUrl = rawImageUrl ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`) : undefined;
 
         nextClothesMap[clothesId] = {
-          id: clothesId,
-          name: item.clothes?.name ?? `옷 ${clothesId}`,
+          id: clothesId, name: item.clothes?.name ?? `옷 ${clothesId}`,
           category: item.clothes?.category ?? item.clothes?.tags?.category ?? '미분류',
           color: item.clothes?.color ?? item.clothes?.tags?.color ?? '색상 정보 없음',
           imageUrl: fullImageUrl,
@@ -148,7 +86,6 @@ export default function HistoryScreen() {
       setHistoryList(mappedHistoryList);
       setClothesMap(nextClothesMap);
     } catch (error: any) {
-      console.error('기록 불러오기 실패:', error);
       if (error.response?.status === 401) setErrorMessage('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
       else setErrorMessage(error.response?.data?.detail || error.message || '기록을 불러오지 못했습니다.');
     } finally {
@@ -157,72 +94,43 @@ export default function HistoryScreen() {
     }
   }, []);
 
-  useFocusEffect(
-    useCallback(() => {
-      fetchHistoryList();
-    }, [fetchHistoryList])
-  );
+  useFocusEffect(useCallback(() => { fetchHistoryList(); }, [fetchHistoryList]));
 
-  // ✨ 선택된 날짜를 API 날짜 포맷(YYYY-MM-DD)으로 변환
-  const formattedFilterDate = filterDate 
-    ? `${filterDate.getFullYear()}-${String(filterDate.getMonth() + 1).padStart(2, '0')}-${String(filterDate.getDate()).padStart(2, '0')}`
-    : null;
+  const formattedFilterDate = filterDate ? `${filterDate.getFullYear()}-${String(filterDate.getMonth() + 1).padStart(2, '0')}-${String(filterDate.getDate()).padStart(2, '0')}` : null;
 
   const handleDateChange = (event: any, date?: Date) => {
     if (Platform.OS === 'android') setShowDatePicker(false);
-    if (event.type === 'dismissed') {
-      return;
-    }
+    if (event.type === 'dismissed') return;
     if (date) setFilterDate(date);
   };
 
   const groupedHistoryData = useMemo(() => {
-    // ✨ 1단계: TPO 및 날짜 필터링 적용
     let filtered = historyList;
-    
-    if (selectedFilter !== '전체') {
-      filtered = filtered.filter((item) => item.tpo === selectedFilter);
-    }
-    
-    if (formattedFilterDate) {
-      filtered = filtered.filter((item) => item.date === formattedFilterDate);
-    }
+    if (selectedFilter !== '전체') filtered = filtered.filter((item) => item.tpo === selectedFilter);
+    if (formattedFilterDate) filtered = filtered.filter((item) => item.date === formattedFilterDate);
 
-    // 2단계: 날짜별로 그룹화
     const groupedMap: Record<string, GroupedWearHistoryItem> = {};
-
     filtered.forEach((item) => {
       const key = item.date;
-
       if (!groupedMap[key]) {
-        groupedMap[key] = {
-          id: key, date: item.date, clothesIds: [...item.clothesIds], historyIds: [item.id],
-          tpoSuitability: item.tpoSuitability || '', mood: item.mood || '', tpo: item.tpo || '', memo: item.memo || '',
-        };
+        groupedMap[key] = { id: key, date: item.date, clothesIds: [...item.clothesIds], historyIds: [item.id], tpoSuitability: item.tpoSuitability || '', mood: item.mood || '', tpo: item.tpo || '', memo: item.memo || '' };
         return;
       }
-
       groupedMap[key].clothesIds.push(...item.clothesIds);
       groupedMap[key].historyIds.push(item.id);
-
       if (!groupedMap[key].tpoSuitability && item.tpoSuitability) groupedMap[key].tpoSuitability = item.tpoSuitability;
       if (!groupedMap[key].mood && item.mood) groupedMap[key].mood = item.mood;
       if (!groupedMap[key].tpo && item.tpo) groupedMap[key].tpo = item.tpo;
       if (!groupedMap[key].memo && item.memo) groupedMap[key].memo = item.memo;
     });
-
     return Object.values(groupedMap).sort((a, b) => b.date.localeCompare(a.date));
   }, [historyList, selectedFilter, formattedFilterDate]);
 
   const deleteHistoryByApi = async (id: string) => {
     const numericId = Number(id);
     if (Number.isNaN(numericId)) throw new Error('유효하지 않은 기록 ID입니다.');
-    try {
-      const response = await api.delete(`/history/${numericId}`);
-      return response.data;
-    } catch (error: any) {
-      throw new Error(error.response?.data?.detail || error.message || '삭제 실패');
-    }
+    const response = await api.delete(`/history/${numericId}`);
+    return response.data;
   };
 
   const handleDelete = (group: GroupedWearHistoryItem) => {
@@ -230,18 +138,13 @@ export default function HistoryScreen() {
     Alert.alert('기록 삭제', '이 날짜의 착용 기록을 모두 삭제할까요?', [
       { text: '취소', style: 'cancel' },
       {
-        text: '삭제',
-        style: 'destructive',
+        text: '삭제', style: 'destructive',
         onPress: async () => {
           try {
             setDeletingId(group.id);
             for (const historyId of group.historyIds) await deleteHistoryByApi(historyId);
             setHistoryList((prev) => prev.filter((item) => !group.historyIds.includes(item.id)));
-          } catch (error) {
-            Alert.alert('삭제 실패', error instanceof Error ? error.message : '서버에서 기록을 삭제하지 못했습니다.');
-          } finally {
-            setDeletingId(null);
-          }
+          } catch (error) { Alert.alert('삭제 실패', error instanceof Error ? error.message : '서버에서 삭제하지 못했습니다.'); } finally { setDeletingId(null); }
         },
       },
     ]);
@@ -251,22 +154,17 @@ export default function HistoryScreen() {
     const clothes = getClothesByIds(group.clothesIds);
     router.push({
       pathname: '/history-detail',
-      params: {
-        id: group.id, date: group.date, tpoSuitability: group.tpoSuitability ?? '', 
-        mood: group.mood ?? '', tpo: group.tpo ?? '', memo: group.memo ?? '',
-        clothes: JSON.stringify(clothes),
-      },
+      params: { id: group.id, date: group.date, tpoSuitability: group.tpoSuitability ?? '', mood: group.mood ?? '', tpo: group.tpo ?? '', memo: group.memo ?? '', clothes: JSON.stringify(clothes) },
     });
   };
 
   const handleEditPress = (group: GroupedWearHistoryItem) => {
-    const clothes = getClothesByIds(group.clothesIds);
     router.push({
       pathname: '/history-create',
       params: {
         editMode: 'true', editId: group.id, editDate: group.date, editMemo: group.memo ?? '',
-        editTpo: group.tpo ?? '', editTpoSuitability: group.tpoSuitability ?? '', 
-        editTemperature: group.mood ?? '', clothes: JSON.stringify(clothes),
+        editTpo: group.tpo ?? '', editTpoSuitability: group.tpoSuitability ?? '', editTemperature: group.mood ?? '', 
+        editClothesIds: JSON.stringify(group.clothesIds), 
         editHistoryIds: JSON.stringify(group.historyIds),
       },
     });
@@ -281,62 +179,26 @@ export default function HistoryScreen() {
     </View>
   );
 
-  if (loading) {
-    return (
-      <SafeAreaView style={styles.loadingContainer}>
-        <ActivityIndicator size="large" />
-        <Text style={styles.emptyDescription}>착용 기록 불러오는 중...</Text>
-      </SafeAreaView>
-    );
-  }
-
-  if (errorMessage && historyList.length === 0) {
-    return (
-      <SafeAreaView style={styles.loadingContainer}>
-        <Text style={styles.emptyTitle}>기록을 불러오지 못했습니다</Text>
-        <Text style={styles.emptyDescription}>{errorMessage}</Text>
-        <View style={styles.errorButtonRow}>
-          <Pressable style={styles.actionButton} onPress={() => fetchHistoryList()}><Text style={styles.actionButtonText}>다시 시도</Text></Pressable>
-        </View>
-      </SafeAreaView>
-    );
-  }
+  if (loading) return <SafeAreaView style={styles.loadingContainer}><ActivityIndicator size="large" /><Text style={styles.emptyDescription}>착용 기록 불러오는 중...</Text></SafeAreaView>;
+  if (errorMessage && historyList.length === 0) return <SafeAreaView style={styles.loadingContainer}><Text style={styles.emptyTitle}>기록을 불러오지 못했습니다</Text><Text style={styles.emptyDescription}>{errorMessage}</Text><View style={styles.errorButtonRow}><Pressable style={styles.actionButton} onPress={() => fetchHistoryList()}><Text style={styles.actionButtonText}>다시 시도</Text></Pressable></View></SafeAreaView>;
 
   return (
     <SafeAreaView style={styles.container}>
-      {/* ✨ 헤더 영역 (날짜 선택 버튼 및 선택된 날짜 뱃지 추가) */}
       <View style={styles.header}>
         <View>
           <Text style={styles.title}>착용 기록</Text>
           {filterDate && (
             <View style={styles.activeDateBadge}>
               <Text style={styles.activeDateText}>{formattedFilterDate?.replace(/-/g, '. ')}</Text>
-              <Pressable onPress={() => setFilterDate(null)} hitSlop={10} style={styles.clearDateIcon}>
-                <Ionicons name="close-circle" size={16} color="#4F46E5" />
-              </Pressable>
+              <Pressable onPress={() => setFilterDate(null)} hitSlop={10} style={styles.clearDateIcon}><Ionicons name="close-circle" size={16} color="#4F46E5" /></Pressable>
             </View>
           )}
         </View>
-        <Pressable style={styles.calendarButton} onPress={() => setShowDatePicker(true)}>
-          <Ionicons name="calendar" size={26} color="#111" />
-        </Pressable>
+        <Pressable style={styles.calendarButton} onPress={() => setShowDatePicker(true)}><Ionicons name="calendar" size={26} color="#111" /></Pressable>
       </View>
 
-      {/* DatePicker 달력 팝업 렌더링 */}
-      {showDatePicker && (
-        <DateTimePicker
-          value={filterDate || new Date()}
-          mode="date"
-          display="default"
-          onChange={handleDateChange}
-        />
-      )}
-      
-      {showDatePicker && Platform.OS === 'ios' && (
-        <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}>
-          <Text style={styles.iosDatePickerDoneText}>닫기</Text>
-        </Pressable>
-      )}
+      {showDatePicker && <DateTimePicker value={filterDate || new Date()} mode="date" display="default" onChange={handleDateChange} />}
+      {showDatePicker && Platform.OS === 'ios' && <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}><Text style={styles.iosDatePickerDoneText}>닫기</Text></Pressable>}
 
       <View>
         <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.filterScroll}>
@@ -360,12 +222,10 @@ export default function HistoryScreen() {
             return (order[a.category] || 99) - (order[b.category] || 99);
           });
           const tagText = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '').join(' · ') || '태그 없음';
-          
           let displayDate = item.date;
           if (item.date) {
-            const dateObj = new Date(item.date);
             const days = ['일', '월', '화', '수', '목', '금', '토'];
-            displayDate = `${item.date.replace(/-/g, '. ')} (${days[dateObj.getDay()]})`;
+            displayDate = `${item.date.replace(/-/g, '. ')} (${days[new Date(item.date).getDay()]})`;
           }
 
           return (
@@ -376,15 +236,11 @@ export default function HistoryScreen() {
                   clothes.map((cloth) => (
                     <View key={cloth.id} style={styles.clothThumbnailBox}>
                       <Text style={styles.clothCategory}>{cloth.category}</Text>
-                      <View style={styles.imageWrapper}>
-                        <Image source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothThumbnailImage} resizeMode="contain" />
-                      </View>
+                      <View style={styles.imageWrapper}><Image source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothThumbnailImage} resizeMode="contain" /></View>
                       <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
                     </View>
                   ))
-                ) : (
-                  <View style={styles.clothBox}><Text style={styles.clothName}>옷 정보 없음</Text></View>
-                )}
+                ) : (<View style={styles.clothBox}><Text style={styles.clothName}>옷 정보 없음</Text></View>)}
               </ScrollView>
 
               <View style={styles.metaContainer}>
@@ -400,16 +256,9 @@ export default function HistoryScreen() {
             </View>
           );
         }}
-        onRefresh={() => fetchHistoryList(true)}
-        refreshing={refreshing}
-        contentContainerStyle={[styles.listContent, groupedHistoryData.length === 0 && styles.emptyListContent]}
-        ListEmptyComponent={<EmptyState />}
-        showsVerticalScrollIndicator={false}
+        onRefresh={() => fetchHistoryList(true)} refreshing={refreshing} contentContainerStyle={[styles.listContent, groupedHistoryData.length === 0 && styles.emptyListContent]} ListEmptyComponent={<EmptyState />} showsVerticalScrollIndicator={false}
       />
-
-      <Pressable style={styles.fab} onPress={handleCreatePress}>
-        <Ionicons name="add" size={28} color="#fff" />
-      </Pressable>
+      <Pressable style={styles.fab} onPress={handleCreatePress}><Ionicons name="add" size={28} color="#fff" /></Pressable>
     </SafeAreaView>
   );
 }
@@ -418,27 +267,21 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff', paddingHorizontal: 16, paddingTop: 16 },
   header: { marginBottom: 16, flexDirection: 'row', justifyContent: 'space-between', alignItems: 'flex-start' },
   title: { fontSize: 28, fontWeight: '800', color: '#111' },
-  
-  // ✨ 날짜 필터 뱃지 및 아이콘 스타일
   calendarButton: { padding: 4 },
   activeDateBadge: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#EEF2FF', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 16, marginTop: 6, alignSelf: 'flex-start', borderWidth: 1, borderColor: '#C7D2FE' },
   activeDateText: { fontSize: 13, fontWeight: '700', color: '#4F46E5' },
   clearDateIcon: { marginLeft: 6 },
-  
   iosDatePickerDone: { alignItems: 'center', backgroundColor: '#E2E8F0', padding: 12, borderRadius: 8, marginBottom: 16 },
   iosDatePickerDoneText: { fontSize: 15, fontWeight: '700', color: '#1E293B' },
-
   filterScroll: { gap: 8, paddingBottom: 16 },
   filterChip: { backgroundColor: '#F1F5F9', borderRadius: 999, paddingHorizontal: 14, paddingVertical: 8, borderWidth: 1, borderColor: '#E2E8F0' },
   filterChipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
   filterChipText: { fontSize: 13, color: '#475569', fontWeight: '600' },
   filterChipTextSelected: { color: '#fff' },
-  
   listContent: { paddingBottom: 24 },
   emptyListContent: { flexGrow: 1 },
   card: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 14, borderWidth: 1, borderColor: '#E2E8F0', shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.03, shadowRadius: 8, elevation: 2 },
   date: { fontSize: 16, fontWeight: '800', color: '#1E293B', marginBottom: 14 },
-  
   clothesScroll: { gap: 14, paddingBottom: 12 },
   clothThumbnailBox: { width: 100, alignItems: 'center' },
   clothCategory: { fontSize: 12, fontWeight: '700', color: '#64748B', marginBottom: 8 },
@@ -446,24 +289,19 @@ const styles = StyleSheet.create({
   clothThumbnailImage: { width: '90%', height: '90%' }, 
   clothName: { fontSize: 13, fontWeight: '700', color: '#334155', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
-  
   metaContainer: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, gap: 8, marginBottom: 12, borderWidth: 1, borderColor: '#F1F5F9' },
   metaRow: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   tagsText: { fontSize: 13, fontWeight: '700', color: '#334155' },
   memoText: { fontSize: 13, color: '#475569', lineHeight: 20 },
-  
   actionRow: { flexDirection: 'row', justifyContent: 'flex-end', gap: 8, marginTop: 12 },
   actionButton: { backgroundColor: '#fff', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 8, paddingHorizontal: 12, paddingVertical: 8 },
   actionButtonText: { fontSize: 13, fontWeight: '700', color: '#475569' },
   deleteButton: { borderColor: '#FECACA' },
   deleteButtonText: { color: '#EF4444' },
-  
   emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   emptyTitle: { fontSize: 17, fontWeight: '800', color: '#1E293B', marginBottom: 8, textAlign: 'center' },
   emptyDescription: { fontSize: 14, color: '#64748B', textAlign: 'center' },
-  
   loadingContainer: { flex: 1, backgroundColor: '#fff', justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
   errorButtonRow: { flexDirection: 'row', gap: 8, marginTop: 16 },
-
   fab: { position: 'absolute', bottom: 24, right: 24, width: 56, height: 56, backgroundColor: '#111', borderRadius: 28, justifyContent: 'center', alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.3, shadowRadius: 4, elevation: 5 },
 });

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -193,12 +193,16 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
         {!apiLoading && apiRecommendations && (
           <View style={{ marginTop: 24 }}>
-            <Text style={styles.sectionTitle}>✨ AI 추천 결과</Text>
-            
-            <View style={styles.contextGroup}>
-              <Text style={styles.contextGroupText}>
-                📍 {recommendContext.address || '위치 알 수 없음'} · 🎯 {recommendContext.situation}
-              </Text>
+
+            <View style={styles.resultHeaderRow}>
+              <View style={styles.contextBadge}>
+                <Ionicons name="location" size={14} color="#64748B" />
+                <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
+              </View>
+              <View style={styles.contextBadge}>
+                <Ionicons name="flag" size={14} color="#64748B" />
+                <Text style={styles.contextBadgeText}>{recommendContext.situation}</Text>
+              </View>
             </View>
 
             <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
@@ -277,8 +281,28 @@ const styles = StyleSheet.create({
   emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
   emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
-  contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
-  contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },
+  resultHeaderRow: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 8, 
+    marginBottom: 16 // 필터와의 간격
+  },
+
+  contextBadge: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    backgroundColor: '#F1F5F9', // 아주 옅은 파스텔 그레이
+    paddingVertical: 6, 
+    paddingHorizontal: 10, 
+    borderRadius: 8, 
+    gap: 4 
+  },
+  
+  contextBadgeText: { 
+    fontSize: 13, 
+    fontWeight: '600', 
+    color: '#475569' 
+  },
 
   aiMessageBox: { 
     backgroundColor: '#F5F8FF', 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -359,14 +359,14 @@ const styles = StyleSheet.create({
     fontSize: 15, 
     color: '#1F2937', 
     lineHeight: 26, 
-    fontWeight: '500' // 👈 600에서 400으로 빼서 눈의 피로도를 낮춤
+    fontWeight: '500'
   },
   
   outfitCard: { marginRight: 16, padding: 16, backgroundColor: '#F8FAFC', borderRadius: 20, borderWidth: 1, borderColor: '#E2E8F0', maxHeight: 600, justifyContent: 'space-between' }, 
   outfitCardHeader: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    gap: 6, // 아이콘과 텍스트 사이 간격
+    gap: 6,
     marginBottom: 12 
   },
 
@@ -377,10 +377,10 @@ const styles = StyleSheet.create({
   },
 
   outfitReasonBox: {
-    backgroundColor: '#F1F5F9', 
+    backgroundColor: '#F8FAFC',
     borderLeftWidth: 3,         
-    borderLeftColor: '#94A3B8', 
-    paddingHorizontal: 14,
+    borderLeftColor: '#3B82F6',
+    paddingHorizontal: 12,
     paddingVertical: 12,
     borderTopRightRadius: 8,
     borderBottomRightRadius: 8,
@@ -388,7 +388,7 @@ const styles = StyleSheet.create({
   },
 
   outfitDescription: { 
-    fontSize: 14, 
+    fontSize: 13.5,
     color: '#334155',
     lineHeight: 22,
     fontWeight: '500'

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -202,8 +202,16 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
             </View>
 
             <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-            {aiMessage && <View style={styles.aiMessageBox}><Text style={styles.aiMessageText}>💬 {aiMessage}</Text></View>}
-            
+            {aiMessage && (
+              <View style={styles.aiMessageBox}>
+                <View style={styles.aiMessageHeader}>
+                  <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                  <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+                </View>
+                <Text style={styles.aiMessageText}>{aiMessage}</Text>
+              </View>
+            )}
+
             <ScrollView 
               horizontal 
               showsHorizontalScrollIndicator={false}
@@ -214,9 +222,15 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               {apiRecommendations.map((outfit, index) => (
                 <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
                   <View style={styles.outfitCardHeader}>
+                    <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
                     <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
                   </View>
-                  {outfit.reason && <Text style={styles.outfitDescription}>{outfit.reason}</Text>}
+
+                  {outfit.reason && (
+                    <View style={styles.outfitReasonBox}>
+                      <Text style={styles.outfitDescription}>{outfit.reason}</Text>
+                    </View>
+                  )}
                   
                   {/* 카드가 너무 길어지지 않게 ScrollView 안에 옷 목록 배치 */}
                   <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
@@ -266,13 +280,63 @@ const styles = StyleSheet.create({
   contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
   contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },
 
-  aiMessageBox: { backgroundColor: '#EEF2FF', padding: 20, borderRadius: 16, marginBottom: 20 },
-  aiMessageText: { fontSize: 15, color: '#3730A3', lineHeight: 24, fontWeight: '600' },
+  aiMessageBox: { 
+    backgroundColor: '#F5F8FF', 
+    padding: 20, 
+    borderRadius: 16, 
+    marginBottom: 20,
+    borderWidth: 1,
+    borderColor: '#E0E7FF'
+  },
+  aiMessageHeader: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 6, 
+    marginBottom: 8 
+  },
+  aiMessageTitle: { 
+    fontSize: 14, 
+    fontWeight: '800', 
+    color: '#4338CA' 
+  },
+  aiMessageText: { 
+    fontSize: 15, 
+    color: '#1F2937', 
+    lineHeight: 26, 
+    fontWeight: '500' // 👈 600에서 400으로 빼서 눈의 피로도를 낮춤
+  },
   
   outfitCard: { marginRight: 16, padding: 16, backgroundColor: '#F8FAFC', borderRadius: 20, borderWidth: 1, borderColor: '#E2E8F0', maxHeight: 600, justifyContent: 'space-between' }, 
-  outfitCardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 },
-  outfitCardTitle: { fontSize: 20, fontWeight: '800', color: '#111827' },
-  outfitDescription: { fontSize: 14, color: '#64748B', marginBottom: 12, lineHeight: 22 },
+  outfitCardHeader: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 6, // 아이콘과 텍스트 사이 간격
+    marginBottom: 12 
+  },
+
+  outfitCardTitle: { 
+    fontSize: 18, // 폰트 크기 살짝 조정
+    fontWeight: '800', 
+    color: '#111827' 
+  },
+
+  outfitReasonBox: {
+    backgroundColor: '#F1F5F9', // 아주 연한 회색으로 옷 카드와 구분
+    borderLeftWidth: 3,         // 왼쪽에만 선을 그어 답답함 해소
+    borderLeftColor: '#94A3B8', // 차분한 슬레이트 그레이 컬러
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    borderTopRightRadius: 8,    // 오른쪽만 살짝 둥글게
+    borderBottomRightRadius: 8,
+    marginBottom: 16
+  },
+
+  outfitDescription: { 
+    fontSize: 14, 
+    color: '#334155',
+    lineHeight: 22,
+    fontWeight: '500'
+  },
   
   // ✨ 착용하기 버튼 스타일 추가
   wearButton: { backgroundColor: '#2563EB', paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 'auto' },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -85,7 +85,7 @@ export default function RecommendScreen() {
       const response = await api.get('/recommend/today', { params: { situation, address } });
 
       setRecommendContext({ situation, address });
-      setAiMessage(response.data.ai_message || '');;
+      setAiMessage(response.data.ai_message || '');
       
       // 3. 옷 매칭 로직 (기존과 동일)
       const matched = response.data.outfits.map((outfit: any) => {
@@ -145,9 +145,20 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-      <Text style={styles.title}>코디 추천</Text>
+      <View style={styles.headerTitleRow}>
+        <Text style={styles.title}>코디 추천</Text>
+        <Ionicons name="shirt" size={28} color="#111827" />
+      </View>
+      <Text style={styles.headerSubtitle}>오늘의 날씨와 외출 목적에 맞는 스타일링</Text>
+
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
+        
+        {/* 2. 변경된 섹션 타이틀 영역 */}
+        <View style={styles.sectionTitleRow}>
+          <Ionicons name="partly-sunny" size={22} color="#2563EB" />
+          <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
+        </View>
+        
         <View style={styles.inputBox}>
           <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
         </View>
@@ -235,9 +246,12 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#F4F6F8' },
   content: { padding: 16, paddingBottom: 40 },
-  title: { fontSize: 30, fontWeight: '800', color: '#111827', marginBottom: 20 },
+  title: { fontSize: 30, fontWeight: '800', color: '#111827', marginBottom: 4 },
+  headerTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 4 },
+  headerSubtitle: { fontSize: 14, color: '#64748B', marginBottom: 20 },
   section: { backgroundColor: '#FFFFFF', borderRadius: 24, padding: 20, marginBottom: 20 },
-  sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 8 },
+  sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 0 },
+  sectionTitleRow: { flexDirection: 'row', alignItems: 'center', gap: 6, marginBottom: 12 },
   inputBox: { backgroundColor: '#F9FAFB', borderRadius: 16, padding: 16, marginBottom: 16, borderWidth: 1, borderColor: '#F1F5F9' },
   textInput: { fontSize: 16, color: '#111827', fontWeight: '600' },
   quickKeywordRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 20 },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -145,56 +145,60 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+      {/* 고정된 상단 헤더 */}
       <View style={styles.headerTitleRow}>
         <Text style={styles.title}>코디 추천</Text>
         <Ionicons name="shirt" size={28} color="#111827" />
       </View>
       <Text style={styles.headerSubtitle}>오늘의 날씨와 외출 목적에 맞는 스타일링</Text>
 
-      <View style={styles.section}>
-        
-        {/* 2. 변경된 섹션 타이틀 영역 */}
-        <View style={styles.sectionTitleRow}>
-          <Ionicons name="partly-sunny" size={22} color="#2563EB" />
-          <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
-        </View>
-        
-        <View style={styles.inputBox}>
-          <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
-        </View>
-
-        <View style={styles.quickKeywordRow}>
-          {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
-            <TouchableOpacity 
-              key={keyword} 
-              style={styles.quickKeywordChip} 
-              onPress={() => setSituation(keyword)}
-            >
-              <Text style={styles.quickKeywordText}>{keyword}</Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-
-        <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
-          <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
-        </TouchableOpacity>
-
-        {apiLoading && <SkeletonLoader />}
-
-        {!apiLoading && !apiRecommendations && (
-          <View style={styles.emptyStateContainer}>
-            <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
-            <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
-            <Text style={styles.emptyStateDesc}>
-              오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
-            </Text>
+      {/* ✨ 1. 추천 결과가 '없을 때'만 보여주는 폼 영역 */}
+      {!apiRecommendations && (
+        <View style={styles.section}>
+          <View style={styles.sectionTitleRow}>
+            <Ionicons name="partly-sunny" size={22} color="#2563EB" />
+            <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
           </View>
-        )}
+          
+          <View style={styles.inputBox}>
+            <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
+          </View>
 
-        {!apiLoading && apiRecommendations && (
-          <View style={{ marginTop: 24 }}>
+          <View style={styles.quickKeywordRow}>
+            {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
+              <TouchableOpacity 
+                key={keyword} 
+                style={styles.quickKeywordChip} 
+                onPress={() => setSituation(keyword)}
+              >
+                <Text style={styles.quickKeywordText}>{keyword}</Text>
+              </TouchableOpacity>
+            ))}
+          </View>
 
-            <View style={styles.resultHeaderRow}>
+          <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
+            <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
+          </TouchableOpacity>
+
+          {apiLoading && <SkeletonLoader />}
+
+          {!apiLoading && (
+            <View style={styles.emptyStateContainer}>
+              <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
+              <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
+              <Text style={styles.emptyStateDesc}>
+                오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
+              </Text>
+            </View>
+          )}
+        </View>
+      )}
+
+      {/* ✨ 2. 추천 결과가 '나왔을 때' 보여주는 결과 전용 화면 (폼은 숨겨짐) */}
+      {apiRecommendations && (
+        <View style={styles.section}>
+          <View style={styles.resultHeaderRow}>
+            <View style={{ flexDirection: 'row', gap: 8, flex: 1 }}>
               <View style={styles.contextBadge}>
                 <Ionicons name="location" size={14} color="#64748B" />
                 <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
@@ -205,58 +209,63 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               </View>
             </View>
 
-            <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-            {aiMessage && (
-              <View style={styles.aiMessageBox}>
-                <View style={styles.aiMessageHeader}>
-                  <Ionicons name="sparkles" size={16} color="#4F46E5" />
-                  <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
-                </View>
-                <Text style={styles.aiMessageText}>{aiMessage}</Text>
-              </View>
-            )}
-
-            <ScrollView 
-              horizontal 
-              showsHorizontalScrollIndicator={false}
-              snapToInterval={CARD_WIDTH + 16}
-              decelerationRate="fast"
-              contentContainerStyle={{ paddingRight: 16, paddingBottom: 10 }}
-            >
-              {apiRecommendations.map((outfit, index) => (
-                <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
-                  <View style={styles.outfitCardHeader}>
-                    <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
-                    <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
-                  </View>
-
-                  {outfit.reason && (
-                    <View style={styles.outfitReasonBox}>
-                      <Text style={styles.outfitDescription}>{outfit.reason}</Text>
-                    </View>
-                  )}
-                  
-                  {/* 카드가 너무 길어지지 않게 ScrollView 안에 옷 목록 배치 */}
-                  <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
-                    {(displayFilter === '전체' || displayFilter === '상의') && outfit.top && <OutfitItemCard label="상의" item={outfit.top} />}
-                    {(displayFilter === '전체' || displayFilter === '하의') && outfit.bottom && <OutfitItemCard label="하의" item={outfit.bottom} />}
-                    {(displayFilter === '전체' || displayFilter === '아우터') && outfit.outer && <OutfitItemCard label="아우터" item={outfit.outer} />}
-                    {(displayFilter === '전체' || displayFilter === '신발') && outfit.shoes && <OutfitItemCard label="신발" item={outfit.shoes} />}
-                  </ScrollView>
-
-                  {/* ✨ 추가된 기능: 추천 코디 착용하기 버튼 */}
-                  <TouchableOpacity 
-                    style={styles.wearButton} 
-                    onPress={() => handleWearOutfit(outfit)}
-                  >
-                    <Text style={styles.wearButtonText}>이 코디 착용하기</Text>
-                  </TouchableOpacity>
-                </View>
-              ))}
-            </ScrollView>
+            {/* ✨ 다시 검색 버튼 */}
+            <TouchableOpacity style={styles.resetButton} onPress={() => setApiRecommendations(null)}>
+              <Ionicons name="refresh" size={14} color="#475569" />
+              <Text style={styles.resetButtonText}>다시 검색</Text>
+            </TouchableOpacity>
           </View>
-        )}
-      </View>
+
+          <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
+          
+          {aiMessage && (
+            <View style={styles.aiMessageBox}>
+              <View style={styles.aiMessageHeader}>
+                <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+              </View>
+              <Text style={styles.aiMessageText}>{aiMessage}</Text>
+            </View>
+          )}
+
+          <ScrollView 
+            horizontal 
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={CARD_WIDTH + 16}
+            decelerationRate="fast"
+            contentContainerStyle={{ paddingRight: 16, paddingBottom: 10 }}
+          >
+            {apiRecommendations.map((outfit, index) => (
+              <View key={index} style={[styles.outfitCard, { width: CARD_WIDTH }]}>
+                <View style={styles.outfitCardHeader}>
+                  <Ionicons name="checkmark-circle" size={22} color="#3B82F6" />
+                  <Text style={styles.outfitCardTitle}>추천 코디 {index + 1}</Text>
+                </View>
+
+                {outfit.reason && (
+                  <View style={styles.outfitReasonBox}>
+                    <Text style={styles.outfitDescription}>{outfit.reason}</Text>
+                  </View>
+                )}
+                
+                <ScrollView nestedScrollEnabled showsVerticalScrollIndicator={false} style={{ flexGrow: 1, marginBottom: 16 }}>
+                  {(displayFilter === '전체' || displayFilter === '상의') && outfit.top && <OutfitItemCard label="상의" item={outfit.top} />}
+                  {(displayFilter === '전체' || displayFilter === '하의') && outfit.bottom && <OutfitItemCard label="하의" item={outfit.bottom} />}
+                  {(displayFilter === '전체' || displayFilter === '아우터') && outfit.outer && <OutfitItemCard label="아우터" item={outfit.outer} />}
+                  {(displayFilter === '전체' || displayFilter === '신발') && outfit.shoes && <OutfitItemCard label="신발" item={outfit.shoes} />}
+                </ScrollView>
+
+                <TouchableOpacity 
+                  style={styles.wearButton} 
+                  onPress={() => handleWearOutfit(outfit)}
+                >
+                  <Text style={styles.wearButtonText}>이 코디 착용하기</Text>
+                </TouchableOpacity>
+              </View>
+            ))}
+          </ScrollView>
+        </View>
+      )}
     </ScrollView>
   );
 }
@@ -297,8 +306,24 @@ const styles = StyleSheet.create({
     borderRadius: 8, 
     gap: 4 
   },
-  
+
   contextBadgeText: { 
+    fontSize: 13, 
+    fontWeight: '600', 
+    color: '#475569' 
+  },
+
+  resetButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#E2E8F0',
+    paddingVertical: 6,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    gap: 4
+  },
+  
+  resetButtonText: { 
     fontSize: 13, 
     fontWeight: '600', 
     color: '#475569' 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from '@expo/vector-icons';
 import * as Location from 'expo-location';
 import { useEffect, useState } from 'react';
 import {
@@ -150,11 +151,34 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
         <View style={styles.inputBox}>
           <TextInput style={styles.textInput} value={situation} onChangeText={setSituation} placeholder="예: 데이트, 출근, 미팅" placeholderTextColor="#9CA3AF" />
         </View>
+
+        <View style={styles.quickKeywordRow}>
+          {['데이트', '출근', '결혼식', '운동', '카페'].map(keyword => (
+            <TouchableOpacity 
+              key={keyword} 
+              style={styles.quickKeywordChip} 
+              onPress={() => setSituation(keyword)}
+            >
+              <Text style={styles.quickKeywordText}>{keyword}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
         <TouchableOpacity style={styles.actionButton} onPress={fetchTodayRecommendation} disabled={apiLoading}>
           <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
         </TouchableOpacity>
 
         {apiLoading && <SkeletonLoader />}
+
+        {!apiLoading && !apiRecommendations && (
+          <View style={styles.emptyStateContainer}>
+            <Ionicons name="sparkles" size={48} color="#D1D5DB" style={{ marginBottom: 16 }} />
+            <Text style={styles.emptyStateTitle}>AI 코디네이터 대기 중</Text>
+            <Text style={styles.emptyStateDesc}>
+              오늘의 외출 목적을 입력하시면,{'\n'}날씨와 옷장 데이터를 분석해 딱 맞는 코디를 제안해 드립니다.
+            </Text>
+          </View>
+        )}
 
         {!apiLoading && apiRecommendations && (
           <View style={{ marginTop: 24 }}>
@@ -216,8 +240,14 @@ const styles = StyleSheet.create({
   sectionTitle: { fontSize: 22, fontWeight: '800', color: '#111827', marginBottom: 8 },
   inputBox: { backgroundColor: '#F9FAFB', borderRadius: 16, padding: 16, marginBottom: 16, borderWidth: 1, borderColor: '#F1F5F9' },
   textInput: { fontSize: 16, color: '#111827', fontWeight: '600' },
+  quickKeywordRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 20 },
+  quickKeywordChip: { backgroundColor: '#F1F5F9', paddingVertical: 8, paddingHorizontal: 14, borderRadius: 20 },
+  quickKeywordText: { fontSize: 13, color: '#475569', fontWeight: '600' },
   actionButton: { backgroundColor: '#111827', borderRadius: 16, paddingVertical: 16, alignItems: 'center' },
   actionButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
+  emptyStateContainer: { alignItems: 'center', justifyContent: 'center', paddingVertical: 60, paddingHorizontal: 20 },
+  emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
+  emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
   contextGroup: { backgroundColor: '#F8FAFC', padding: 12, borderRadius: 12, marginBottom: 16, borderWidth: 1, borderColor: '#E2E8F0', alignItems: 'center' },
   contextGroupText: { fontSize: 14, fontWeight: '700', color: '#475569' },

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -74,7 +74,7 @@ export default function RecommendScreen() {
     try {
       setApiLoading(true);
       
-      // 1. 위치 정보는 정상적으로 가져옴 (테스트 환경에서도 중요)
+      // 1. 위치 정보는 정상적으로 가져옴
       const { status } = await Location.requestForegroundPermissionsAsync();
       if (status !== 'granted') return Alert.alert('권한 필요', '위치 권한이 필요합니다.');
 
@@ -118,12 +118,12 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
     // 🎯 오늘 날짜를 백엔드 포맷(YYYY-MM-DD)에 맞게 생성
     const todayStr = new Date().toISOString().slice(0, 10);
 
-    // 선택된 코디에서 존재하는 옷들만 필터링하고 worn_date 필드 필수 추가!
+    // 선택된 코디에서 존재하는 옷들만 필터링하고 worn_date 필드 필수 추가
     const payload = [outfit.top, outfit.bottom, outfit.outer, outfit.shoes]
       .filter(Boolean)
       .map(cloth => ({
         clothes_id: Number(cloth!.id),
-        worn_date: todayStr // 👈 이 필드가 누락되어 422 에러가 났던 것입니다.
+        worn_date: todayStr
       }));
 
     if (payload.length === 0) {
@@ -197,36 +197,28 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
       {/* ✨ 2. 추천 결과가 '나왔을 때' 보여주는 결과 전용 화면 (폼은 숨겨짐) */}
       {apiRecommendations && (
         <View style={styles.section}>
+          
+          {/* ✨ 양쪽 정렬로 깔끔하게 정리된 헤더 */}
           <View style={styles.resultHeaderRow}>
-            <View style={{ flexDirection: 'row', gap: 8, flex: 1 }}>
-              <View style={styles.contextBadge}>
-                <Ionicons name="location" size={14} color="#64748B" />
-                <Text style={styles.contextBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
+            <View style={{ flexDirection: 'row', gap: 8 }}>
+              <View style={styles.locationBadge}>
+                <Ionicons name="location" size={12} color="#64748B" />
+                <Text style={styles.locationBadgeText}>{recommendContext.address || '위치 알 수 없음'}</Text>
               </View>
-              <View style={styles.contextBadge}>
-                <Ionicons name="flag" size={14} color="#64748B" />
-                <Text style={styles.contextBadgeText}>{recommendContext.situation}</Text>
+              <View style={styles.tpoBadge}>
+                <Ionicons name="flag" size={12} color="#2563EB" />
+                <Text style={styles.tpoBadgeText}>{recommendContext.situation}</Text>
               </View>
             </View>
 
-            {/* ✨ 다시 검색 버튼 */}
+            {/* ✨ 회색 덩어리를 없애고 가벼운 텍스트 버튼으로 우측 배치 */}
             <TouchableOpacity style={styles.resetButton} onPress={() => setApiRecommendations(null)}>
-              <Ionicons name="refresh" size={14} color="#475569" />
+              <Ionicons name="refresh" size={14} color="#64748B" />
               <Text style={styles.resetButtonText}>다시 검색</Text>
             </TouchableOpacity>
           </View>
 
           <RecommendFilter activeFilter={displayFilter} onFilterChange={setDisplayFilter} />
-          
-          {aiMessage && (
-            <View style={styles.aiMessageBox}>
-              <View style={styles.aiMessageHeader}>
-                <Ionicons name="sparkles" size={16} color="#4F46E5" />
-                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
-              </View>
-              <Text style={styles.aiMessageText}>{aiMessage}</Text>
-            </View>
-          )}
 
           <ScrollView 
             horizontal 
@@ -264,6 +256,17 @@ const handleWearOutfit = async (outfit: OutfitSet) => {
               </View>
             ))}
           </ScrollView>
+
+          {aiMessage && (
+            <View style={styles.aiMessageBox}>
+              <View style={styles.aiMessageHeader}>
+                <Ionicons name="sparkles" size={16} color="#4F46E5" />
+                <Text style={styles.aiMessageTitle}>AI 스타일링 포인트</Text>
+              </View>
+              <Text style={styles.aiMessageText}>{aiMessage}</Text>
+            </View>
+          )}
+
         </View>
       )}
     </ScrollView>
@@ -290,44 +293,48 @@ const styles = StyleSheet.create({
   emptyStateTitle: { fontSize: 18, fontWeight: '700', color: '#64748B', marginBottom: 8 },
   emptyStateDesc: { fontSize: 14, color: '#94A3B8', textAlign: 'center', lineHeight: 22 },
   
+ 
   resultHeaderRow: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    gap: 8, 
-    marginBottom: 16 // 필터와의 간격
+    justifyContent: 'space-between',
+    marginBottom: 16
   },
 
-  contextBadge: { 
+
+  locationBadge: { 
     flexDirection: 'row', 
     alignItems: 'center', 
-    backgroundColor: '#F1F5F9', // 아주 옅은 파스텔 그레이
+    backgroundColor: '#F1F5F9', 
     paddingVertical: 6, 
     paddingHorizontal: 10, 
     borderRadius: 8, 
     gap: 4 
   },
+  locationBadgeText: { fontSize: 13, fontWeight: '600', color: '#475569' },
 
-  contextBadgeText: { 
-    fontSize: 13, 
-    fontWeight: '600', 
-    color: '#475569' 
+
+  tpoBadge: {
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    backgroundColor: '#EFF6FF', 
+    paddingVertical: 6, 
+    paddingHorizontal: 10, 
+    borderRadius: 8, 
+    gap: 4,
+    borderWidth: 1,
+    borderColor: '#BFDBFE' 
   },
+  tpoBadgeText: { fontSize: 13, fontWeight: '700', color: '#1D4ED8' }, 
 
   resetButton: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#E2E8F0',
+    gap: 4,
     paddingVertical: 6,
-    paddingHorizontal: 12,
-    borderRadius: 8,
-    gap: 4
+    paddingHorizontal: 8,
   },
-  
-  resetButtonText: { 
-    fontSize: 13, 
-    fontWeight: '600', 
-    color: '#475569' 
-  },
+  resetButtonText: { fontSize: 13, fontWeight: '600', color: '#64748B' },
 
   aiMessageBox: { 
     backgroundColor: '#F5F8FF', 
@@ -370,12 +377,12 @@ const styles = StyleSheet.create({
   },
 
   outfitReasonBox: {
-    backgroundColor: '#F1F5F9', // 아주 연한 회색으로 옷 카드와 구분
-    borderLeftWidth: 3,         // 왼쪽에만 선을 그어 답답함 해소
-    borderLeftColor: '#94A3B8', // 차분한 슬레이트 그레이 컬러
+    backgroundColor: '#F1F5F9', 
+    borderLeftWidth: 3,         
+    borderLeftColor: '#94A3B8', 
     paddingHorizontal: 14,
     paddingVertical: 12,
-    borderTopRightRadius: 8,    // 오른쪽만 살짝 둥글게
+    borderTopRightRadius: 8,
     borderBottomRightRadius: 8,
     marginBottom: 16
   },
@@ -387,7 +394,7 @@ const styles = StyleSheet.create({
     fontWeight: '500'
   },
   
-  // ✨ 착용하기 버튼 스타일 추가
+
   wearButton: { backgroundColor: '#2563EB', paddingVertical: 14, borderRadius: 12, alignItems: 'center', marginTop: 'auto' },
   wearButtonText: { color: '#FFFFFF', fontSize: 16, fontWeight: '700' },
 

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -1,3 +1,4 @@
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
@@ -5,6 +6,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  Platform,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -22,8 +24,6 @@ type ClothesApiItem = { clothes_id?: number; id?: number; name?: string; categor
 const tpoOptions = ['데일리', '비즈니스', '면접', '결혼식', '장례식', '운동', '데이트', '모임', '여행'];
 const tpoSuitabilityOptions = ['잘 어울림', '보통', '안 어울림']; 
 const temperatureOptions = ['추움', '적당함', '더움']; 
-
-function formatToday() { return new Date().toISOString().slice(0, 10); }
 
 function normalizeCategory(category?: string) {
   const value = (category || '').trim().toLowerCase();
@@ -49,16 +49,27 @@ export default function HistoryCreateScreen() {
 
   const isEditMode = params.editMode === 'true';
   
-  // 서버 전송용 원본 날짜 (YYYY-MM-DD)
-  const rawDate = isEditMode && params.editDate ? params.editDate : formatToday();
-  
-  // 화면 표시용 예쁜 날짜 (YYYY. MM. DD (요일))
-  let uiDate = rawDate;
-  if (/^\d{4}-\d{2}-\d{2}$/.test(rawDate)) {
-    const dateObj = new Date(rawDate);
-    const days = ['일', '월', '화', '수', '목', '금', '토'];
-    uiDate = `${rawDate.replace(/-/g, '. ')} (${days[dateObj.getDay()]})`;
-  }
+  // ✨ 날짜 관련 상태 (DatePicker용)
+  const initialDate = (isEditMode && params.editDate) ? new Date(params.editDate) : new Date();
+  const [selectedDate, setSelectedDate] = useState<Date>(initialDate);
+  const [showDatePicker, setShowDatePicker] = useState(false);
+
+  const handleDateChange = (event: any, date?: Date) => {
+    // 안드로이드는 선택 후 자동으로 닫히고, iOS는 모달을 유지해야 할 수 있음
+    if (Platform.OS === 'android') {
+      setShowDatePicker(false);
+    }
+    if (date) {
+      setSelectedDate(date);
+    }
+  };
+
+  // UI에 보여질 예쁜 날짜 포맷 생성
+  const days = ['일', '월', '화', '수', '목', '금', '토'];
+  const yyyy = selectedDate.getFullYear();
+  const mm = String(selectedDate.getMonth() + 1).padStart(2, '0');
+  const dd = String(selectedDate.getDate()).padStart(2, '0');
+  const uiDate = `${yyyy}. ${mm}. ${dd} (${days[selectedDate.getDay()]})`;
 
   const [clothesList, setClothesList] = useState<ClothingItem[]>([]);
   const [selectedClothes, setSelectedClothes] = useState<string[]>([]);
@@ -156,18 +167,13 @@ export default function HistoryCreateScreen() {
 
   const toggleCloth = (id: string, category: string) => {
     setSelectedClothes((prev) => {
-      // 1. 이미 선택된 옷을 다시 누르면 선택 해제
       if (prev.includes(id)) {
         return prev.filter((itemId) => itemId !== id);
       }
-      
-      // 2. 새로운 옷을 선택한 경우, 같은 카테고리의 다른 옷이 이미 선택되어 있다면 제거
       const filteredPrev = prev.filter((prevId) => {
         const prevCloth = clothesList.find((c) => c.id === prevId);
         return prevCloth?.category !== category;
       });
-      
-      // 3. 같은 카테고리의 기존 옷이 지워진 상태에서 새 옷 추가
       return [...filteredPrev, id];
     });
   };
@@ -198,16 +204,17 @@ export default function HistoryCreateScreen() {
 
     try {
       setSaving(true);
+      
+      // ✨ 서버 전송용 날짜 포맷 (YYYY-MM-DD)
+      const submitDate = `${yyyy}-${mm}-${dd}`;
 
       const payload = selectedClothes.map((clothesId) => {
         const numericId = Number(clothesId);
-        if (isNaN(numericId)) {
-          throw new Error(`유효하지 않은 옷 ID가 포함되어 있습니다: ${clothesId}`);
-        }
+        if (isNaN(numericId)) throw new Error(`유효하지 않은 옷 ID: ${clothesId}`);
 
         return {
           clothes_id: numericId,
-          worn_date: rawDate, 
+          worn_date: submitDate, 
           tpo: tpo && tpo.trim() !== "" ? tpo.trim() : null,
           style: null,
           mood: null,
@@ -230,11 +237,7 @@ export default function HistoryCreateScreen() {
       }
     } catch (error: any) {
       console.error('착용 기록 저장 실패:', error);
-      if (error.response && error.response.data) {
-        Alert.alert('저장 실패 (422)', JSON.stringify(error.response.data.detail));
-      } else {
-        Alert.alert('저장 실패', error.message || '서버 오류가 발생했습니다.');
-      }
+      Alert.alert('저장 실패', error.response?.data?.detail || error.message || '서버 오류가 발생했습니다.');
     } finally {
       setSaving(false);
     }
@@ -252,16 +255,32 @@ export default function HistoryCreateScreen() {
         ) : (
           <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
             
-            {/* ✨ 날짜 섹션: 달력 아이콘과 전용 박스로 강조 */}
+            {/* ✨ 날짜 선택 영역: 터치 시 팝업 띄우기 */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>날짜</Text>
-              <View style={styles.dateBox}>
+              <Pressable style={styles.dateBox} onPress={() => setShowDatePicker(true)}>
                 <Ionicons name="calendar-clear-outline" size={24} color="#4F46E5" />
                 <Text style={styles.dateText}>{uiDate}</Text>
-              </View>
+              </Pressable>
             </View>
 
-            {/* ✨ 입은 옷 섹션: 이미지 썸네일 카드로 개편 */}
+            {/* DatePicker 달력 팝업 렌더링 */}
+            {showDatePicker && (
+              <DateTimePicker
+                value={selectedDate}
+                mode="date"
+                display="default"
+                onChange={handleDateChange}
+              />
+            )}
+            
+            {/* iOS에서 모달을 직접 닫는 버튼 (필요 시) */}
+            {showDatePicker && Platform.OS === 'ios' && (
+              <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}>
+                <Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text>
+              </Pressable>
+            )}
+
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>오늘 입은 옷</Text>
               {isUsingMockData && <Text style={styles.mockWarningText}>⚠️ 서버 연결 안됨 (더미 데이터 표시 중)</Text>}
@@ -286,7 +305,6 @@ export default function HistoryCreateScreen() {
                                 style={styles.clothImage} 
                                 resizeMode="contain" 
                               />
-                              {/* 선택 시 나타나는 보라색 반투명 오버레이와 체크 표시 */}
                               {isSelected && (
                                 <View style={styles.checkOverlay}>
                                   <Ionicons name="checkmark-circle" size={28} color="#fff" />
@@ -307,7 +325,6 @@ export default function HistoryCreateScreen() {
               )}
             </View>
 
-            {/* ✨ 폼 섹션: 넓고 깔끔한 디자인 */}
             <View style={styles.section}><Text style={styles.sectionTitle}>TPO (상황)</Text>{renderChips(tpoOptions, tpo, setTpo)}</View>
             <View style={styles.section}><Text style={styles.sectionTitle}>TPO 적합도</Text>{renderChips(tpoSuitabilityOptions, tpoSuitability, setTpoSuitability)}</View>
             <View style={styles.section}><Text style={styles.sectionTitle}>체감온도</Text>{renderChips(temperatureOptions, temperature, setTemperature)}</View>
@@ -340,31 +357,42 @@ const styles = StyleSheet.create({
   section: { marginBottom: 32 },
   sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 14 },
   
-  // ✨ 날짜 강조 영역
   dateBox: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#F8FAFC', padding: 16, borderRadius: 12, gap: 10, borderWidth: 1, borderColor: '#E2E8F0' },
   dateText: { fontSize: 16, fontWeight: '700', color: '#1E293B' },
+  
+  iosDatePickerDone: { alignItems: 'center', backgroundColor: '#E2E8F0', padding: 12, borderRadius: 8, marginBottom: 20 },
+  iosDatePickerDoneText: { fontSize: 15, fontWeight: '700', color: '#1E293B' },
   
   categoryBlock: { marginBottom: 20 },
   subTitle: { fontSize: 14, fontWeight: '700', color: '#64748B', marginBottom: 12 },
   
-  // ✨ 옷 이미지 썸네일 카드 영역
   clothRowScroll: { flexDirection: 'row', gap: 12, paddingBottom: 4, paddingRight: 16 },
   clothCard: { width: 90, alignItems: 'center' },
   imageContainer: { width: 90, height: 90, borderRadius: 12, backgroundColor: '#F1F5F9', marginBottom: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', borderWidth: 2, borderColor: 'transparent' },
-  imageContainerSelected: { borderColor: '#4F46E5' }, // 선택 시 보라색 테두리
+  imageContainerSelected: { borderColor: '#4F46E5' }, 
   clothImage: { width: '90%', height: '90%' },
   checkOverlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(79, 70, 229, 0.5)', justifyContent: 'center', alignItems: 'center' },
   clothName: { fontSize: 13, color: '#475569', textAlign: 'center', fontWeight: '500' },
   clothNameSelected: { color: '#4F46E5', fontWeight: '700' },
   
-  // ✨ 태그(칩) 선택 영역
+  // ✨ 피드백 칩(태그) 크기 축소 영역
   chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  chip: { paddingHorizontal: 16, paddingVertical: 10, borderRadius: 20, backgroundColor: '#FFFFFF', borderWidth: 1, borderColor: '#E2E8F0' },
+  chip: { 
+    paddingHorizontal: 14, // 기존 16 -> 14로 축소
+    paddingVertical: 8,    // 기존 10 -> 8로 축소
+    borderRadius: 18,      
+    backgroundColor: '#FFFFFF', 
+    borderWidth: 1, 
+    borderColor: '#E2E8F0' 
+  },
   chipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
-  chipText: { fontSize: 14, color: '#64748B', fontWeight: '600' },
+  chipText: { 
+    fontSize: 13, // 기존 14 -> 13으로 축소
+    color: '#64748B', 
+    fontWeight: '600' 
+  },
   chipTextSelected: { color: '#FFFFFF' },
   
-  // ✨ 메모 입력 영역
   input: { backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 12, padding: 16, minHeight: 120, textAlignVertical: 'top', fontSize: 15, color: '#334155', lineHeight: 22 },
   
   saveButton: { marginTop: 10, backgroundColor: '#111', paddingVertical: 16, borderRadius: 12, alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 6, elevation: 3 },

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -6,6 +6,7 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  KeyboardAvoidingView,
   Platform,
   Pressable,
   SafeAreaView,
@@ -78,7 +79,6 @@ export default function HistoryCreateScreen() {
       if (params.editTpoSuitability) setTpoSuitability(params.editTpoSuitability); 
       if (params.editTemperature) setTemperature(params.editTemperature === '적당' ? '적당함' : params.editTemperature);
       
-      // ✨ 파라미터 호환성을 완벽하게 처리하여 무조건 체크 표시가 복구되도록 수정
       try {
         let idsToSelect: string[] = [];
         if (params.editClothesIds) {
@@ -200,65 +200,76 @@ export default function HistoryCreateScreen() {
     <>
       <Stack.Screen options={{ title: isEditMode ? '착용 기록 수정' : '착용 기록 추가' }} />
       <SafeAreaView style={styles.container}>
-        {loadingClothes ? (
-          <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111" /><Text style={styles.loadingText}>옷 목록 불러오는 중...</Text></View>
-        ) : (
-          <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-            
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>날짜</Text>
-              <Pressable style={styles.dateBox} onPress={() => setShowDatePicker(true)}>
-                <Ionicons name="calendar-clear-outline" size={24} color="#4F46E5" />
-                <Text style={styles.dateText}>{uiDate}</Text>
-              </Pressable>
-            </View>
-
-            {showDatePicker && <DateTimePicker value={selectedDate} mode="date" display="default" onChange={handleDateChange} />}
-            {showDatePicker && Platform.OS === 'ios' && <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}><Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text></Pressable>}
-
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>오늘 입은 옷</Text>
-              {isUsingMockData && <Text style={styles.mockWarningText}>⚠️ 서버 연결 안됨 (더미 데이터 표시 중)</Text>}
+        {/* ✨ 키보드 회피 뷰 적용 */}
+        <KeyboardAvoidingView 
+          style={{ flex: 1 }} 
+          behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+          keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
+        >
+          {loadingClothes ? (
+            <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111" /><Text style={styles.loadingText}>옷 목록 불러오는 중...</Text></View>
+          ) : (
+            <ScrollView 
+              contentContainerStyle={styles.content} 
+              showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled" // ✨ 키보드 열린 상태에서도 버튼 탭 유지
+            >
               
-              {groupedClothes.length > 0 ? (
-                groupedClothes.map((group) => (
-                  <View key={group.title} style={styles.categoryBlock}>
-                    <Text style={styles.subTitle}>{group.title}</Text>
-                    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothRowScroll}>
-                      {group.items.map((item) => {
-                        const isSelected = selectedClothes.includes(item.id);
-                        return (
-                          <Pressable key={item.id} style={styles.clothCard} onPress={() => toggleCloth(item.id, item.category)}>
-                            <View style={[styles.imageContainer, isSelected && styles.imageContainerSelected]}>
-                              <Image source={{ uri: item.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothImage} resizeMode="contain" />
-                              {isSelected && <View style={styles.checkOverlay}><Ionicons name="checkmark-circle" size={28} color="#fff" /></View>}
-                            </View>
-                            <Text style={[styles.clothName, isSelected && styles.clothNameSelected]} numberOfLines={1}>{item.name}</Text>
-                          </Pressable>
-                        );
-                      })}
-                    </ScrollView>
-                  </View>
-                ))
-              ) : (
-                !isUsingMockData && <Text style={styles.emptyText}>선택할 수 있는 옷이 없습니다.</Text>
-              )}
-            </View>
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>날짜</Text>
+                <Pressable style={styles.dateBox} onPress={() => setShowDatePicker(true)}>
+                  <Ionicons name="calendar-clear-outline" size={24} color="#4F46E5" />
+                  <Text style={styles.dateText}>{uiDate}</Text>
+                </Pressable>
+              </View>
 
-            <View style={styles.section}><Text style={styles.sectionTitle}>TPO (상황)</Text>{renderChips(tpoOptions, tpo, setTpo)}</View>
-            <View style={styles.section}><Text style={styles.sectionTitle}>TPO 적합도</Text>{renderChips(tpoSuitabilityOptions, tpoSuitability, setTpoSuitability)}</View>
-            <View style={styles.section}><Text style={styles.sectionTitle}>체감온도</Text>{renderChips(temperatureOptions, temperature, setTemperature)}</View>
-            
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>메모</Text>
-              <TextInput style={styles.input} placeholder="오늘 착장에 대한 메모를 편하게 남겨주세요." placeholderTextColor="#94A3B8" value={memo} onChangeText={setMemo} multiline />
-            </View>
+              {showDatePicker && <DateTimePicker value={selectedDate} mode="date" display="default" onChange={handleDateChange} />}
+              {showDatePicker && Platform.OS === 'ios' && <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}><Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text></Pressable>}
 
-            <Pressable style={[styles.saveButton, (saving || isUsingMockData) && styles.saveButtonDisabled]} onPress={handleSave} disabled={saving || isUsingMockData}>
-              <Text style={styles.saveText}>{saving ? '저장 중...' : (isEditMode ? '수정 완료' : '저장하기')}</Text>
-            </Pressable>
-          </ScrollView>
-        )}
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>오늘 입은 옷</Text>
+                {isUsingMockData && <Text style={styles.mockWarningText}>⚠️ 서버 연결 안됨 (더미 데이터 표시 중)</Text>}
+                
+                {groupedClothes.length > 0 ? (
+                  groupedClothes.map((group) => (
+                    <View key={group.title} style={styles.categoryBlock}>
+                      <Text style={styles.subTitle}>{group.title}</Text>
+                      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothRowScroll}>
+                        {group.items.map((item) => {
+                          const isSelected = selectedClothes.includes(item.id);
+                          return (
+                            <Pressable key={item.id} style={styles.clothCard} onPress={() => toggleCloth(item.id, item.category)}>
+                              <View style={[styles.imageContainer, isSelected && styles.imageContainerSelected]}>
+                                <Image source={{ uri: item.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothImage} resizeMode="contain" />
+                                {isSelected && <View style={styles.checkOverlay}><Ionicons name="checkmark-circle" size={28} color="#fff" /></View>}
+                              </View>
+                              <Text style={[styles.clothName, isSelected && styles.clothNameSelected]} numberOfLines={1}>{item.name}</Text>
+                            </Pressable>
+                          );
+                        })}
+                      </ScrollView>
+                    </View>
+                  ))
+                ) : (
+                  !isUsingMockData && <Text style={styles.emptyText}>선택할 수 있는 옷이 없습니다.</Text>
+                )}
+              </View>
+
+              <View style={styles.section}><Text style={styles.sectionTitle}>TPO (상황)</Text>{renderChips(tpoOptions, tpo, setTpo)}</View>
+              <View style={styles.section}><Text style={styles.sectionTitle}>TPO 적합도</Text>{renderChips(tpoSuitabilityOptions, tpoSuitability, setTpoSuitability)}</View>
+              <View style={styles.section}><Text style={styles.sectionTitle}>체감온도</Text>{renderChips(temperatureOptions, temperature, setTemperature)}</View>
+              
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>메모</Text>
+                <TextInput style={styles.input} placeholder="오늘 착장에 대한 메모를 편하게 남겨주세요." placeholderTextColor="#94A3B8" value={memo} onChangeText={setMemo} multiline />
+              </View>
+
+              <Pressable style={[styles.saveButton, (saving || isUsingMockData) && styles.saveButtonDisabled]} onPress={handleSave} disabled={saving || isUsingMockData}>
+                <Text style={styles.saveText}>{saving ? '저장 중...' : (isEditMode ? '수정 완료' : '저장하기')}</Text>
+              </Pressable>
+            </ScrollView>
+          )}
+        </KeyboardAvoidingView>
       </SafeAreaView>
     </>
   );

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -36,41 +36,24 @@ function normalizeCategory(category?: string) {
 }
 
 export default function HistoryCreateScreen() {
-  // ✨ editHistoryIds 파라미터 추가
   const params = useLocalSearchParams<{
-    editMode?: string;
-    editId?: string;
-    editDate?: string;
-    editMemo?: string;
-    editTpo?: string;
-    editTpoSuitability?: string; 
-    editTemperature?: string;
-    editClothes?: string;
-    editHistoryIds?: string; 
+    editMode?: string; editId?: string; editDate?: string; editMemo?: string;
+    editTpo?: string; editTpoSuitability?: string; editTemperature?: string;
+    editClothesIds?: string; editClothes?: string; editHistoryIds?: string; 
   }>();
 
   const isEditMode = params.editMode === 'true';
-  
-  // 날짜 관련 상태 (DatePicker용)
   const initialDate = (isEditMode && params.editDate) ? new Date(params.editDate) : new Date();
+  
   const [selectedDate, setSelectedDate] = useState<Date>(initialDate);
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   const handleDateChange = (event: any, date?: Date) => {
-    if (Platform.OS === 'android') {
-      setShowDatePicker(false);
-    }
-
-    if (event.type === 'dismissed') {
-      return;
-    }
-
-    if (date) {
-      setSelectedDate(date);
-    }
+    if (Platform.OS === 'android') setShowDatePicker(false);
+    if (event.type === 'dismissed') return;
+    if (date) setSelectedDate(date);
   };
 
-  // UI에 보여질 날짜 포맷 (YYYY. MM. DD (요일))
   const days = ['일', '월', '화', '수', '목', '금', '토'];
   const yyyy = selectedDate.getFullYear();
   const mm = String(selectedDate.getMonth() + 1).padStart(2, '0');
@@ -93,21 +76,26 @@ export default function HistoryCreateScreen() {
       if (params.editMemo) setMemo(params.editMemo);
       if (params.editTpo) setTpo(params.editTpo);
       if (params.editTpoSuitability) setTpoSuitability(params.editTpoSuitability); 
+      if (params.editTemperature) setTemperature(params.editTemperature === '적당' ? '적당함' : params.editTemperature);
       
-      if (params.editTemperature) {
-        setTemperature(params.editTemperature === '적당' ? '적당함' : params.editTemperature);
-      }
-      
-      if (params.editClothes) {
-        try {
-          const parsedClothes: ClothingItem[] = JSON.parse(params.editClothes);
-          setSelectedClothes(parsedClothes.map((cloth) => String(cloth.id)));
-        } catch (e) {
-          console.error('옷 데이터 파싱 에러:', e);
+      // ✨ 파라미터 호환성을 완벽하게 처리하여 무조건 체크 표시가 복구되도록 수정
+      try {
+        let idsToSelect: string[] = [];
+        if (params.editClothesIds) {
+          const parsedIds = JSON.parse(params.editClothesIds);
+          idsToSelect = parsedIds.map(String);
+        } else if (params.editClothes) {
+          const parsedClothes = JSON.parse(params.editClothes);
+          idsToSelect = parsedClothes.map((cloth: any) => String(cloth.id));
         }
+        if (idsToSelect.length > 0) {
+          setSelectedClothes(idsToSelect);
+        }
+      } catch (e) {
+        console.error('옷 선택 복구 에러:', e);
       }
     }
-  }, [isEditMode, params.editMemo, params.editTpo, params.editTpoSuitability, params.editTemperature, params.editClothes]);
+  }, [isEditMode, params.editMemo, params.editTpo, params.editTpoSuitability, params.editTemperature, params.editClothesIds, params.editClothes]);
 
   useEffect(() => {
     const fetchClothes = async () => {
@@ -118,43 +106,26 @@ export default function HistoryCreateScreen() {
         const mapped: ClothingItem[] = data.map((item, index) => {
           const rawId = item.clothes_id ?? item.id;
           if (rawId === undefined || rawId === null) return null;
-          const rawCategory = item.category ?? item.tags?.category;
-          const rawColor = item.color ?? item.tags?.color ?? '';
-          
           const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
           const rawImageUrl = item.image_url;
-          const fullImageUrl = rawImageUrl 
-            ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`)
-            : undefined;
-
           return { 
-            id: String(rawId), 
-            name: item.name?.trim() || `옷 ${index + 1}`, 
-            category: normalizeCategory(rawCategory), 
-            color: rawColor,
-            imageUrl: fullImageUrl 
+            id: String(rawId), name: item.name?.trim() || `옷 ${index + 1}`, 
+            category: normalizeCategory(item.category ?? item.tags?.category), color: item.color ?? item.tags?.color ?? '',
+            imageUrl: rawImageUrl ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`) : undefined 
           };
         }).filter(Boolean) as ClothingItem[];
 
         if (mapped.length === 0) {
           setIsUsingMockData(true);
-          setClothesList([
-            { id: '1', name: '블랙 셔츠', category: '상의' },
-            { id: '2', name: '베이지 슬랙스', category: '하의' },
-          ]);
+          setClothesList([{ id: '1', name: '블랙 셔츠', category: '상의' }, { id: '2', name: '베이지 슬랙스', category: '하의' }]);
         } else {
           setIsUsingMockData(false);
           setClothesList(mapped);
         }
       } catch (error: any) {
-        console.error('옷 목록 불러오기 실패:', error);
         setIsUsingMockData(true);
-        if (error.response?.status === 401) {
-          Alert.alert('인증 오류', '세션이 만료되었습니다. 다시 로그인해주세요.');
-        }
-      } finally {
-        setLoadingClothes(false);
-      }
+        if (error.response?.status === 401) Alert.alert('인증 오류', '세션이 만료되었습니다. 다시 로그인해주세요.');
+      } finally { setLoadingClothes(false); }
     };
     fetchClothes();
   }, []);
@@ -173,13 +144,8 @@ export default function HistoryCreateScreen() {
 
   const toggleCloth = (id: string, category: string) => {
     setSelectedClothes((prev) => {
-      if (prev.includes(id)) {
-        return prev.filter((itemId) => itemId !== id);
-      }
-      const filteredPrev = prev.filter((prevId) => {
-        const prevCloth = clothesList.find((c) => c.id === prevId);
-        return prevCloth?.category !== category;
-      });
+      if (prev.includes(id)) return prev.filter((itemId) => itemId !== id);
+      const filteredPrev = prev.filter((prevId) => clothesList.find((c) => c.id === prevId)?.category !== category);
       return [...filteredPrev, id];
     });
   };
@@ -187,11 +153,7 @@ export default function HistoryCreateScreen() {
   const renderChips = (options: string[], selected: string, setValue: (value: string) => void) => (
     <View style={styles.chipRow}>
       {options.map((option) => (
-        <Pressable
-          key={option}
-          style={[styles.chip, selected === option && styles.chipSelected]}
-          onPress={() => setValue(option)}
-        >
+        <Pressable key={option} style={[styles.chip, selected === option && styles.chipSelected]} onPress={() => setValue(option)}>
           <Text style={[styles.chipText, selected === option && styles.chipTextSelected]}>{option}</Text>
         </Pressable>
       ))}
@@ -199,69 +161,39 @@ export default function HistoryCreateScreen() {
   );
 
   const handleSave = async () => {
-    if (isUsingMockData) {
-      Alert.alert('안내', '현재는 더미 데이터 상태라 저장이 불가능합니다. 다시 로그인해주세요.');
-      return;
-    }
-    if (selectedClothes.length === 0) {
-      Alert.alert('안내', '옷을 선택해주세요.');
-      return;
-    }
+    if (isUsingMockData) { Alert.alert('안내', '더미 데이터 상태입니다. 다시 로그인해주세요.'); return; }
+    if (selectedClothes.length === 0) { Alert.alert('안내', '옷을 선택해주세요.'); return; }
 
     try {
       setSaving(true);
-      
       const submitDate = `${yyyy}-${mm}-${dd}`;
-
-      const payload = selectedClothes.map((clothesId) => {
-        const numericId = Number(clothesId);
-        if (isNaN(numericId)) throw new Error(`유효하지 않은 옷 ID: ${clothesId}`);
-
-        return {
-          clothes_id: numericId,
-          worn_date: submitDate, 
-          tpo: tpo && tpo.trim() !== "" ? tpo.trim() : null,
-          style: null,
-          mood: null,
-          feedback_temperature: temperature && temperature.trim() !== "" ? temperature.trim() : null,
-          feedback_tpo: tpoSuitability && tpoSuitability.trim() !== "" ? tpoSuitability.trim() : null,
-          memo: memo && memo.trim() !== "" ? memo.trim() : null,
-        };
-      });
+      const payload = selectedClothes.map((clothesId) => ({
+        clothes_id: Number(clothesId), worn_date: submitDate, 
+        tpo: tpo && tpo.trim() !== "" ? tpo.trim() : null, style: null, mood: null,
+        feedback_temperature: temperature && temperature.trim() !== "" ? temperature.trim() : null,
+        feedback_tpo: tpoSuitability && tpoSuitability.trim() !== "" ? tpoSuitability.trim() : null,
+        memo: memo && memo.trim() !== "" ? memo.trim() : null,
+      }));
 
       if (isEditMode) {
         const originalDate = params.editDate;
-        
-        // ✨ 날짜가 변경되었을 경우: 새 날짜로 POST하고, 기존 기록들은 DELETE 처리
         if (originalDate && submitDate !== originalDate) {
           await api.post('/history', payload);
-          
           if (params.editHistoryIds) {
             const oldIds = JSON.parse(params.editHistoryIds);
-            for (const id of oldIds) {
-              await api.delete(`/history/${Number(id)}`);
-            }
+            for (const id of oldIds) await api.delete(`/history/${Number(id)}`);
           }
         } else {
-          // 날짜가 같을 경우: 기존 기록 덮어쓰기 (PUT)
           await api.put(`/history`, payload); 
         }
-
-        Alert.alert('수정 완료', '착용 기록이 수정되었습니다.', [
-          { text: '확인', onPress: () => router.replace('/(tabs)/history') },
-        ]);
+        Alert.alert('수정 완료', '착용 기록이 수정되었습니다.', [{ text: '확인', onPress: () => router.replace('/(tabs)/history') }]);
       } else {
         await api.post('/history', payload);
-        Alert.alert('저장 완료', '착용 기록이 저장되었습니다.', [
-          { text: '확인', onPress: () => router.replace('/(tabs)/history') },
-        ]);
+        Alert.alert('저장 완료', '착용 기록이 저장되었습니다.', [{ text: '확인', onPress: () => router.replace('/(tabs)/history') }]);
       }
     } catch (error: any) {
-      console.error('착용 기록 저장 실패:', error);
       Alert.alert('저장 실패', error.response?.data?.detail || error.message || '서버 오류가 발생했습니다.');
-    } finally {
-      setSaving(false);
-    }
+    } finally { setSaving(false); }
   };
 
   return (
@@ -269,10 +201,7 @@ export default function HistoryCreateScreen() {
       <Stack.Screen options={{ title: isEditMode ? '착용 기록 수정' : '착용 기록 추가' }} />
       <SafeAreaView style={styles.container}>
         {loadingClothes ? (
-          <View style={styles.loadingContainer}>
-            <ActivityIndicator size="large" color="#111" />
-            <Text style={styles.loadingText}>옷 목록 불러오는 중...</Text>
-          </View>
+          <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111" /><Text style={styles.loadingText}>옷 목록 불러오는 중...</Text></View>
         ) : (
           <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
             
@@ -284,20 +213,8 @@ export default function HistoryCreateScreen() {
               </Pressable>
             </View>
 
-            {showDatePicker && (
-              <DateTimePicker
-                value={selectedDate}
-                mode="date"
-                display="default"
-                onChange={handleDateChange}
-              />
-            )}
-            
-            {showDatePicker && Platform.OS === 'ios' && (
-              <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}>
-                <Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text>
-              </Pressable>
-            )}
+            {showDatePicker && <DateTimePicker value={selectedDate} mode="date" display="default" onChange={handleDateChange} />}
+            {showDatePicker && Platform.OS === 'ios' && <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}><Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text></Pressable>}
 
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>오늘 입은 옷</Text>
@@ -307,31 +224,16 @@ export default function HistoryCreateScreen() {
                 groupedClothes.map((group) => (
                   <View key={group.title} style={styles.categoryBlock}>
                     <Text style={styles.subTitle}>{group.title}</Text>
-
                     <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothRowScroll}>
                       {group.items.map((item) => {
                         const isSelected = selectedClothes.includes(item.id);
                         return (
-                          <Pressable
-                            key={item.id}
-                            style={styles.clothCard}
-                            onPress={() => toggleCloth(item.id, item.category)}
-                          >
+                          <Pressable key={item.id} style={styles.clothCard} onPress={() => toggleCloth(item.id, item.category)}>
                             <View style={[styles.imageContainer, isSelected && styles.imageContainerSelected]}>
-                              <Image 
-                                source={{ uri: item.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
-                                style={styles.clothImage} 
-                                resizeMode="contain" 
-                              />
-                              {isSelected && (
-                                <View style={styles.checkOverlay}>
-                                  <Ionicons name="checkmark-circle" size={28} color="#fff" />
-                                </View>
-                              )}
+                              <Image source={{ uri: item.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} style={styles.clothImage} resizeMode="contain" />
+                              {isSelected && <View style={styles.checkOverlay}><Ionicons name="checkmark-circle" size={28} color="#fff" /></View>}
                             </View>
-                            <Text style={[styles.clothName, isSelected && styles.clothNameSelected]} numberOfLines={1}>
-                              {item.name}
-                            </Text>
+                            <Text style={[styles.clothName, isSelected && styles.clothNameSelected]} numberOfLines={1}>{item.name}</Text>
                           </Pressable>
                         );
                       })}
@@ -349,14 +251,7 @@ export default function HistoryCreateScreen() {
             
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>메모</Text>
-              <TextInput 
-                style={styles.input} 
-                placeholder="오늘 착장에 대한 메모를 편하게 남겨주세요." 
-                placeholderTextColor="#94A3B8"
-                value={memo} 
-                onChangeText={setMemo} 
-                multiline 
-              />
+              <TextInput style={styles.input} placeholder="오늘 착장에 대한 메모를 편하게 남겨주세요." placeholderTextColor="#94A3B8" value={memo} onChangeText={setMemo} multiline />
             </View>
 
             <Pressable style={[styles.saveButton, (saving || isUsingMockData) && styles.saveButtonDisabled]} onPress={handleSave} disabled={saving || isUsingMockData}>
@@ -374,16 +269,12 @@ const styles = StyleSheet.create({
   content: { padding: 16, paddingBottom: 60 },
   section: { marginBottom: 32 },
   sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 14 },
-  
   dateBox: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#F8FAFC', padding: 16, borderRadius: 12, gap: 10, borderWidth: 1, borderColor: '#E2E8F0' },
   dateText: { fontSize: 16, fontWeight: '700', color: '#1E293B' },
-  
   iosDatePickerDone: { alignItems: 'center', backgroundColor: '#E2E8F0', padding: 12, borderRadius: 8, marginBottom: 20 },
   iosDatePickerDoneText: { fontSize: 15, fontWeight: '700', color: '#1E293B' },
-  
   categoryBlock: { marginBottom: 20 },
   subTitle: { fontSize: 14, fontWeight: '700', color: '#64748B', marginBottom: 12 },
-  
   clothRowScroll: { flexDirection: 'row', gap: 12, paddingBottom: 4, paddingRight: 16 },
   clothCard: { width: 90, alignItems: 'center' },
   imageContainer: { width: 90, height: 90, borderRadius: 12, backgroundColor: '#F1F5F9', marginBottom: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', borderWidth: 2, borderColor: 'transparent' },
@@ -392,30 +283,15 @@ const styles = StyleSheet.create({
   checkOverlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(79, 70, 229, 0.5)', justifyContent: 'center', alignItems: 'center' },
   clothName: { fontSize: 13, color: '#475569', textAlign: 'center', fontWeight: '500' },
   clothNameSelected: { color: '#4F46E5', fontWeight: '700' },
-  
   chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  chip: { 
-    paddingHorizontal: 14, 
-    paddingVertical: 8,    
-    borderRadius: 18,      
-    backgroundColor: '#FFFFFF', 
-    borderWidth: 1, 
-    borderColor: '#E2E8F0' 
-  },
+  chip: { paddingHorizontal: 14, paddingVertical: 8, borderRadius: 18, backgroundColor: '#FFFFFF', borderWidth: 1, borderColor: '#E2E8F0' },
   chipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
-  chipText: { 
-    fontSize: 13, 
-    color: '#64748B', 
-    fontWeight: '600' 
-  },
+  chipText: { fontSize: 13, color: '#64748B', fontWeight: '600' },
   chipTextSelected: { color: '#FFFFFF' },
-  
   input: { backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 12, padding: 16, minHeight: 120, textAlignVertical: 'top', fontSize: 15, color: '#334155', lineHeight: 22 },
-  
   saveButton: { marginTop: 10, backgroundColor: '#111', paddingVertical: 16, borderRadius: 12, alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 6, elevation: 3 },
   saveButtonDisabled: { opacity: 0.5 },
   saveText: { color: '#fff', fontSize: 17, fontWeight: '700' },
-  
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   loadingText: { marginTop: 12, fontSize: 14, color: '#64748B' },
   mockWarningText: { fontSize: 13, color: '#EF4444', marginBottom: 12, fontWeight: '600' },

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -1,8 +1,10 @@
+import { Ionicons } from '@expo/vector-icons';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
+  Image,
   Pressable,
   SafeAreaView,
   ScrollView,
@@ -14,12 +16,11 @@ import {
 
 import api from './_api';
 
-type ClothingItem = { id: string; name: string; category: string; color?: string; };
-type ClothesApiItem = { clothes_id?: number; id?: number; name?: string; category?: string; color?: string; tags?: { category?: string; color?: string; [key: string]: any; }; };
+type ClothingItem = { id: string; name: string; category: string; color?: string; imageUrl?: string; };
+type ClothesApiItem = { clothes_id?: number; id?: number; name?: string; category?: string; color?: string; image_url?: string; tags?: { category?: string; color?: string; [key: string]: any; }; };
 
 const tpoOptions = ['데일리', '비즈니스', '면접', '결혼식', '장례식', '운동', '데이트', '모임', '여행'];
 const tpoSuitabilityOptions = ['잘 어울림', '보통', '안 어울림']; 
-// ✅ 백엔드 Enum 스펙에 맞춰 '적당' -> '적당함'으로 수정
 const temperatureOptions = ['추움', '적당함', '더움']; 
 
 function formatToday() { return new Date().toISOString().slice(0, 10); }
@@ -47,7 +48,17 @@ export default function HistoryCreateScreen() {
   }>();
 
   const isEditMode = params.editMode === 'true';
-  const displayDate = isEditMode && params.editDate ? params.editDate : formatToday();
+  
+  // 서버 전송용 원본 날짜 (YYYY-MM-DD)
+  const rawDate = isEditMode && params.editDate ? params.editDate : formatToday();
+  
+  // 화면 표시용 예쁜 날짜 (YYYY. MM. DD (요일))
+  let uiDate = rawDate;
+  if (/^\d{4}-\d{2}-\d{2}$/.test(rawDate)) {
+    const dateObj = new Date(rawDate);
+    const days = ['일', '월', '화', '수', '목', '금', '토'];
+    uiDate = `${rawDate.replace(/-/g, '. ')} (${days[dateObj.getDay()]})`;
+  }
 
   const [clothesList, setClothesList] = useState<ClothingItem[]>([]);
   const [selectedClothes, setSelectedClothes] = useState<string[]>([]);
@@ -66,7 +77,6 @@ export default function HistoryCreateScreen() {
       if (params.editTpo) setTpo(params.editTpo);
       if (params.editTpoSuitability) setTpoSuitability(params.editTpoSuitability); 
       
-      // ✅ 기존 데이터가 '적당'일 경우 '적당함'으로 보정해서 칩 맵칭 보장
       if (params.editTemperature) {
         setTemperature(params.editTemperature === '적당' ? '적당함' : params.editTemperature);
       }
@@ -93,7 +103,20 @@ export default function HistoryCreateScreen() {
           if (rawId === undefined || rawId === null) return null;
           const rawCategory = item.category ?? item.tags?.category;
           const rawColor = item.color ?? item.tags?.color ?? '';
-          return { id: String(rawId), name: item.name?.trim() || `옷 ${index + 1}`, category: normalizeCategory(rawCategory), color: rawColor };
+          
+          const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
+          const rawImageUrl = item.image_url;
+          const fullImageUrl = rawImageUrl 
+            ? (rawImageUrl.startsWith('http') ? rawImageUrl : `${API_BASE_URL}${rawImageUrl}`)
+            : undefined;
+
+          return { 
+            id: String(rawId), 
+            name: item.name?.trim() || `옷 ${index + 1}`, 
+            category: normalizeCategory(rawCategory), 
+            color: rawColor,
+            imageUrl: fullImageUrl 
+          };
         }).filter(Boolean) as ClothingItem[];
 
         if (mapped.length === 0) {
@@ -131,10 +154,22 @@ export default function HistoryCreateScreen() {
     return groups.filter((g) => g.items.length > 0);
   }, [clothesList]);
 
-  const toggleCloth = (id: string) => {
-    setSelectedClothes((prev) =>
-      prev.includes(id) ? prev.filter((item) => item !== id) : [...prev, id]
-    );
+  const toggleCloth = (id: string, category: string) => {
+    setSelectedClothes((prev) => {
+      // 1. 이미 선택된 옷을 다시 누르면 선택 해제
+      if (prev.includes(id)) {
+        return prev.filter((itemId) => itemId !== id);
+      }
+      
+      // 2. 새로운 옷을 선택한 경우, 같은 카테고리의 다른 옷이 이미 선택되어 있다면 제거
+      const filteredPrev = prev.filter((prevId) => {
+        const prevCloth = clothesList.find((c) => c.id === prevId);
+        return prevCloth?.category !== category;
+      });
+      
+      // 3. 같은 카테고리의 기존 옷이 지워진 상태에서 새 옷 추가
+      return [...filteredPrev, id];
+    });
   };
 
   const renderChips = (options: string[], selected: string, setValue: (value: string) => void) => (
@@ -164,19 +199,6 @@ export default function HistoryCreateScreen() {
     try {
       setSaving(true);
 
-      let targetDate = typeof displayDate === 'string' ? displayDate.trim() : String(displayDate);
-      if (targetDate.includes('T')) {
-        targetDate = targetDate.split('T')[0];
-      }
-      targetDate = targetDate.slice(0, 10);
-
-      const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
-      if (!dateRegex.test(targetDate)) {
-        Alert.alert('오류', `날짜 형식이 유효하지 않습니다: ${targetDate}`);
-        setSaving(false);
-        return;
-      }
-
       const payload = selectedClothes.map((clothesId) => {
         const numericId = Number(clothesId);
         if (isNaN(numericId)) {
@@ -185,7 +207,7 @@ export default function HistoryCreateScreen() {
 
         return {
           clothes_id: numericId,
-          worn_date: targetDate, 
+          worn_date: rawDate, 
           tpo: tpo && tpo.trim() !== "" ? tpo.trim() : null,
           style: null,
           mood: null,
@@ -196,13 +218,11 @@ export default function HistoryCreateScreen() {
       });
 
       if (isEditMode) {
-        // PUT 요청은 명세서 및 라우터 구조상 리스트 형태 고정 전송
         await api.put(`/history`, payload); 
         Alert.alert('수정 완료', '착용 기록이 수정되었습니다.', [
           { text: '확인', onPress: () => router.replace('/(tabs)/history') },
         ]);
       } else {
-        // ✅ POST /history 전송 시 Union 검증기 우회를 위해 리스트 래핑 규격 안정화 보장
         await api.post('/history', payload);
         Alert.alert('저장 완료', '착용 기록이 저장되었습니다.', [
           { text: '확인', onPress: () => router.replace('/(tabs)/history') },
@@ -230,31 +250,56 @@ export default function HistoryCreateScreen() {
             <Text style={styles.loadingText}>옷 목록 불러오는 중...</Text>
           </View>
         ) : (
-          <ScrollView contentContainerStyle={styles.content}>
+          <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+            
+            {/* ✨ 날짜 섹션: 달력 아이콘과 전용 박스로 강조 */}
             <View style={styles.section}>
-              <Text style={styles.title}>날짜</Text>
-              <Text style={styles.value}>{displayDate}</Text>
+              <Text style={styles.sectionTitle}>날짜</Text>
+              <View style={styles.dateBox}>
+                <Ionicons name="calendar-clear-outline" size={24} color="#4F46E5" />
+                <Text style={styles.dateText}>{uiDate}</Text>
+              </View>
             </View>
 
+            {/* ✨ 입은 옷 섹션: 이미지 썸네일 카드로 개편 */}
             <View style={styles.section}>
-              <Text style={styles.title}>오늘 입은 옷</Text>
+              <Text style={styles.sectionTitle}>오늘 입은 옷</Text>
               {isUsingMockData && <Text style={styles.mockWarningText}>⚠️ 서버 연결 안됨 (더미 데이터 표시 중)</Text>}
               
               {groupedClothes.length > 0 ? (
                 groupedClothes.map((group) => (
                   <View key={group.title} style={styles.categoryBlock}>
                     <Text style={styles.subTitle}>{group.title}</Text>
-                    <View style={styles.clothRow}>
-                      {group.items.map((item) => (
-                        <Pressable
-                          key={item.id}
-                          style={[styles.clothBox, selectedClothes.includes(item.id) && styles.clothBoxSelected]}
-                          onPress={() => toggleCloth(item.id)}
-                        >
-                          <Text style={[styles.clothName, selectedClothes.includes(item.id) && styles.clothNameSelected]}>{item.name}</Text>
-                        </Pressable>
-                      ))}
-                    </View>
+
+                    <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.clothRowScroll}>
+                      {group.items.map((item) => {
+                        const isSelected = selectedClothes.includes(item.id);
+                        return (
+                          <Pressable
+                            key={item.id}
+                            style={styles.clothCard}
+                            onPress={() => toggleCloth(item.id, item.category)}
+                          >
+                            <View style={[styles.imageContainer, isSelected && styles.imageContainerSelected]}>
+                              <Image 
+                                source={{ uri: item.imageUrl || 'https://via.placeholder.com/100?text=No+Img' }} 
+                                style={styles.clothImage} 
+                                resizeMode="contain" 
+                              />
+                              {/* 선택 시 나타나는 보라색 반투명 오버레이와 체크 표시 */}
+                              {isSelected && (
+                                <View style={styles.checkOverlay}>
+                                  <Ionicons name="checkmark-circle" size={28} color="#fff" />
+                                </View>
+                              )}
+                            </View>
+                            <Text style={[styles.clothName, isSelected && styles.clothNameSelected]} numberOfLines={1}>
+                              {item.name}
+                            </Text>
+                          </Pressable>
+                        );
+                      })}
+                    </ScrollView>
                   </View>
                 ))
               ) : (
@@ -262,12 +307,21 @@ export default function HistoryCreateScreen() {
               )}
             </View>
 
-            <View style={styles.section}><Text style={styles.title}>TPO (상황)</Text>{renderChips(tpoOptions, tpo, setTpo)}</View>
-            <View style={styles.section}><Text style={styles.title}>TPO 적합도</Text>{renderChips(tpoSuitabilityOptions, tpoSuitability, setTpoSuitability)}</View>
-            <View style={styles.section}><Text style={styles.title}>체감온도</Text>{renderChips(temperatureOptions, temperature, setTemperature)}</View>
+            {/* ✨ 폼 섹션: 넓고 깔끔한 디자인 */}
+            <View style={styles.section}><Text style={styles.sectionTitle}>TPO (상황)</Text>{renderChips(tpoOptions, tpo, setTpo)}</View>
+            <View style={styles.section}><Text style={styles.sectionTitle}>TPO 적합도</Text>{renderChips(tpoSuitabilityOptions, tpoSuitability, setTpoSuitability)}</View>
+            <View style={styles.section}><Text style={styles.sectionTitle}>체감온도</Text>{renderChips(temperatureOptions, temperature, setTemperature)}</View>
+            
             <View style={styles.section}>
-              <Text style={styles.title}>메모</Text>
-              <TextInput style={styles.input} placeholder="오늘 착장에 대한 메모를 입력하세요" value={memo} onChangeText={setMemo} multiline />
+              <Text style={styles.sectionTitle}>메모</Text>
+              <TextInput 
+                style={styles.input} 
+                placeholder="오늘 착장에 대한 메모를 편하게 남겨주세요." 
+                placeholderTextColor="#94A3B8"
+                value={memo} 
+                onChangeText={setMemo} 
+                multiline 
+              />
             </View>
 
             <Pressable style={[styles.saveButton, (saving || isUsingMockData) && styles.saveButtonDisabled]} onPress={handleSave} disabled={saving || isUsingMockData}>
@@ -282,28 +336,43 @@ export default function HistoryCreateScreen() {
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
-  content: { padding: 16, paddingBottom: 40 },
-  section: { marginBottom: 20 },
-  categoryBlock: { marginTop: 12 },
-  title: { fontSize: 16, fontWeight: '700', marginBottom: 8 },
-  subTitle: { fontSize: 14, fontWeight: '600', color: '#555', marginBottom: 8 },
-  value: { fontSize: 15, color: '#111' },
-  clothRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  clothBox: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 8, backgroundColor: '#f1f1f1' },
-  clothBoxSelected: { backgroundColor: '#111' },
-  clothName: { color: '#333', fontSize: 13 },
-  clothNameSelected: { color: '#fff', fontWeight: '600' },
+  content: { padding: 16, paddingBottom: 60 },
+  section: { marginBottom: 32 },
+  sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 14 },
+  
+  // ✨ 날짜 강조 영역
+  dateBox: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#F8FAFC', padding: 16, borderRadius: 12, gap: 10, borderWidth: 1, borderColor: '#E2E8F0' },
+  dateText: { fontSize: 16, fontWeight: '700', color: '#1E293B' },
+  
+  categoryBlock: { marginBottom: 20 },
+  subTitle: { fontSize: 14, fontWeight: '700', color: '#64748B', marginBottom: 12 },
+  
+  // ✨ 옷 이미지 썸네일 카드 영역
+  clothRowScroll: { flexDirection: 'row', gap: 12, paddingBottom: 4, paddingRight: 16 },
+  clothCard: { width: 90, alignItems: 'center' },
+  imageContainer: { width: 90, height: 90, borderRadius: 12, backgroundColor: '#F1F5F9', marginBottom: 8, overflow: 'hidden', justifyContent: 'center', alignItems: 'center', borderWidth: 2, borderColor: 'transparent' },
+  imageContainerSelected: { borderColor: '#4F46E5' }, // 선택 시 보라색 테두리
+  clothImage: { width: '90%', height: '90%' },
+  checkOverlay: { position: 'absolute', top: 0, left: 0, right: 0, bottom: 0, backgroundColor: 'rgba(79, 70, 229, 0.5)', justifyContent: 'center', alignItems: 'center' },
+  clothName: { fontSize: 13, color: '#475569', textAlign: 'center', fontWeight: '500' },
+  clothNameSelected: { color: '#4F46E5', fontWeight: '700' },
+  
+  // ✨ 태그(칩) 선택 영역
   chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
-  chip: { paddingHorizontal: 12, paddingVertical: 8, borderRadius: 999, backgroundColor: '#f1f1f1' },
-  chipSelected: { backgroundColor: '#111' },
-  chipText: { fontSize: 13, color: '#333' },
-  chipTextSelected: { color: '#fff', fontWeight: '600' },
-  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 10, padding: 12, minHeight: 80, textAlignVertical: 'top' },
-  saveButton: { marginTop: 10, backgroundColor: '#111', paddingVertical: 14, borderRadius: 12, alignItems: 'center' },
-  saveButtonDisabled: { opacity: 0.6 },
-  saveText: { color: '#fff', fontSize: 16, fontWeight: '700' },
-  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', paddingHorizontal: 24 },
-  loadingText: { marginTop: 12, fontSize: 14, color: '#777' },
-  mockWarningText: { fontSize: 13, color: '#c0392b', marginBottom: 8, lineHeight: 18 },
-  emptyText: { fontSize: 14, color: '#888', marginTop: 4 },
+  chip: { paddingHorizontal: 16, paddingVertical: 10, borderRadius: 20, backgroundColor: '#FFFFFF', borderWidth: 1, borderColor: '#E2E8F0' },
+  chipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
+  chipText: { fontSize: 14, color: '#64748B', fontWeight: '600' },
+  chipTextSelected: { color: '#FFFFFF' },
+  
+  // ✨ 메모 입력 영역
+  input: { backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 12, padding: 16, minHeight: 120, textAlignVertical: 'top', fontSize: 15, color: '#334155', lineHeight: 22 },
+  
+  saveButton: { marginTop: 10, backgroundColor: '#111', paddingVertical: 16, borderRadius: 12, alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 6, elevation: 3 },
+  saveButtonDisabled: { opacity: 0.5 },
+  saveText: { color: '#fff', fontSize: 17, fontWeight: '700' },
+  
+  loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
+  loadingText: { marginTop: 12, fontSize: 14, color: '#64748B' },
+  mockWarningText: { fontSize: 13, color: '#EF4444', marginBottom: 12, fontWeight: '600' },
+  emptyText: { fontSize: 14, color: '#94A3B8', marginTop: 4 },
 });

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -1,5 +1,5 @@
-import DateTimePicker from '@react-native-community/datetimepicker';
 import { Ionicons } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
 import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { useEffect, useMemo, useState } from 'react';
 import {
@@ -36,6 +36,7 @@ function normalizeCategory(category?: string) {
 }
 
 export default function HistoryCreateScreen() {
+  // ✨ editHistoryIds 파라미터 추가
   const params = useLocalSearchParams<{
     editMode?: string;
     editId?: string;
@@ -45,17 +46,17 @@ export default function HistoryCreateScreen() {
     editTpoSuitability?: string; 
     editTemperature?: string;
     editClothes?: string;
+    editHistoryIds?: string; 
   }>();
 
   const isEditMode = params.editMode === 'true';
   
-  // ✨ 날짜 관련 상태 (DatePicker용)
+  // 날짜 관련 상태 (DatePicker용)
   const initialDate = (isEditMode && params.editDate) ? new Date(params.editDate) : new Date();
   const [selectedDate, setSelectedDate] = useState<Date>(initialDate);
   const [showDatePicker, setShowDatePicker] = useState(false);
 
   const handleDateChange = (event: any, date?: Date) => {
-    // 안드로이드는 선택 후 자동으로 닫히고, iOS는 모달을 유지해야 할 수 있음
     if (Platform.OS === 'android') {
       setShowDatePicker(false);
     }
@@ -64,7 +65,7 @@ export default function HistoryCreateScreen() {
     }
   };
 
-  // UI에 보여질 예쁜 날짜 포맷 생성
+  // UI에 보여질 날짜 포맷 (YYYY. MM. DD (요일))
   const days = ['일', '월', '화', '수', '목', '금', '토'];
   const yyyy = selectedDate.getFullYear();
   const mm = String(selectedDate.getMonth() + 1).padStart(2, '0');
@@ -205,7 +206,6 @@ export default function HistoryCreateScreen() {
     try {
       setSaving(true);
       
-      // ✨ 서버 전송용 날짜 포맷 (YYYY-MM-DD)
       const submitDate = `${yyyy}-${mm}-${dd}`;
 
       const payload = selectedClothes.map((clothesId) => {
@@ -225,7 +225,23 @@ export default function HistoryCreateScreen() {
       });
 
       if (isEditMode) {
-        await api.put(`/history`, payload); 
+        const originalDate = params.editDate;
+        
+        // ✨ 날짜가 변경되었을 경우: 새 날짜로 POST하고, 기존 기록들은 DELETE 처리
+        if (originalDate && submitDate !== originalDate) {
+          await api.post('/history', payload);
+          
+          if (params.editHistoryIds) {
+            const oldIds = JSON.parse(params.editHistoryIds);
+            for (const id of oldIds) {
+              await api.delete(`/history/${Number(id)}`);
+            }
+          }
+        } else {
+          // 날짜가 같을 경우: 기존 기록 덮어쓰기 (PUT)
+          await api.put(`/history`, payload); 
+        }
+
         Alert.alert('수정 완료', '착용 기록이 수정되었습니다.', [
           { text: '확인', onPress: () => router.replace('/(tabs)/history') },
         ]);
@@ -255,7 +271,6 @@ export default function HistoryCreateScreen() {
         ) : (
           <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
             
-            {/* ✨ 날짜 선택 영역: 터치 시 팝업 띄우기 */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>날짜</Text>
               <Pressable style={styles.dateBox} onPress={() => setShowDatePicker(true)}>
@@ -264,7 +279,6 @@ export default function HistoryCreateScreen() {
               </Pressable>
             </View>
 
-            {/* DatePicker 달력 팝업 렌더링 */}
             {showDatePicker && (
               <DateTimePicker
                 value={selectedDate}
@@ -274,7 +288,6 @@ export default function HistoryCreateScreen() {
               />
             )}
             
-            {/* iOS에서 모달을 직접 닫는 버튼 (필요 시) */}
             {showDatePicker && Platform.OS === 'ios' && (
               <Pressable style={styles.iosDatePickerDone} onPress={() => setShowDatePicker(false)}>
                 <Text style={styles.iosDatePickerDoneText}>날짜 선택 완료</Text>
@@ -375,11 +388,10 @@ const styles = StyleSheet.create({
   clothName: { fontSize: 13, color: '#475569', textAlign: 'center', fontWeight: '500' },
   clothNameSelected: { color: '#4F46E5', fontWeight: '700' },
   
-  // ✨ 피드백 칩(태그) 크기 축소 영역
   chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   chip: { 
-    paddingHorizontal: 14, // 기존 16 -> 14로 축소
-    paddingVertical: 8,    // 기존 10 -> 8로 축소
+    paddingHorizontal: 14, 
+    paddingVertical: 8,    
     borderRadius: 18,      
     backgroundColor: '#FFFFFF', 
     borderWidth: 1, 
@@ -387,7 +399,7 @@ const styles = StyleSheet.create({
   },
   chipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
   chipText: { 
-    fontSize: 13, // 기존 14 -> 13으로 축소
+    fontSize: 13, 
     color: '#64748B', 
     fontWeight: '600' 
   },

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -60,6 +60,11 @@ export default function HistoryCreateScreen() {
     if (Platform.OS === 'android') {
       setShowDatePicker(false);
     }
+
+    if (event.type === 'dismissed') {
+      return;
+    }
+
     if (date) {
       setSelectedDate(date);
     }

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -33,23 +33,22 @@ export default function HistoryDetailScreen() {
 
       <SafeAreaView style={styles.container}>
         <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
-          <View style={styles.summaryCard}>
-            <View style={styles.summaryRow}>
-              <Text style={styles.summaryLabel}>날짜</Text>
-              <Text style={styles.summaryValue}>{params.date || '-'}</Text>
+          <View style={styles.headerArea}>
+            <Text style={styles.headerDate}>{params.date || '-'}</Text>
+            
+            <View style={styles.headerTagRow}>
+              {feedbackTags.length > 0 ? (
+                feedbackTags.map((tag, index) => (
+                  <View key={index} style={styles.headerTagChip}>
+                    <Text style={styles.headerTagText}>{tag}</Text>
+                  </View>
+                ))
+              ) : (
+                <Text style={styles.emptyText}>태그 없음</Text>
+              )}
             </View>
 
-            <View style={styles.summaryRow}>
-              <Text style={styles.summaryLabel}>태그</Text>
-              <Text style={styles.summaryValue}>
-                {feedbackTags.length > 0 ? feedbackTags.join(' · ') : '없음'}
-              </Text>
-            </View>
-
-            <View style={styles.memoBox}>
-              <Text style={styles.summaryLabel}>메모</Text>
-              <Text style={styles.memoText}>{params.memo || '메모 없음'}</Text>
-            </View>
+            <Text style={styles.headerMemoText}>{params.memo || '입력된 메모가 없습니다.'}</Text>
           </View>
 
           <View style={styles.section}>
@@ -91,30 +90,13 @@ const styles = StyleSheet.create({
   section: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
   sectionTitle: { fontSize: 14, fontWeight: '700', color: '#555', marginBottom: 8 },
   
-  summaryCard: { 
-    backgroundColor: '#f8f9fa', 
-    borderRadius: 14, 
-    padding: 18, 
-    marginBottom: 24,
-    borderWidth: 1,
-    borderColor: '#f1f1f1'
-  },
-  summaryRow: { 
-    flexDirection: 'row', 
-    marginBottom: 12 
-  },
-  summaryLabel: { 
-    width: 70, 
-    fontSize: 14, 
-    fontWeight: '700', 
-    color: '#888' 
-  },
-  summaryValue: { 
-    flex: 1, 
-    fontSize: 15, 
-    color: '#222', 
-    fontWeight: '600' 
-  },
+  headerArea: { paddingVertical: 10, marginBottom: 24, paddingHorizontal: 4 },
+  headerDate: { fontSize: 28, fontWeight: '800', color: '#111', marginBottom: 12 },
+  headerTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 16 },
+  headerTagChip: { backgroundColor: '#f1f5f9', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
+  headerTagText: { fontSize: 13, fontWeight: '600', color: '#475569' },
+  headerMemoText: { fontSize: 15, color: '#334155', lineHeight: 24 },
+  
   memoBox: { 
     marginTop: 4, 
     paddingTop: 16, 

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -25,20 +25,20 @@ export default function HistoryDetailScreen() {
     ? JSON.parse(params.clothes)
     : [];
 
+  // ✨ 옷 카테고리 순서대로 정렬 (아우터 > 상의 > 하의 > 신발)
   clothes.sort((a, b) => {
     const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
     return (order[a.category] || 99) - (order[b.category] || 99);
   });
-  
+
   const feedbackTags = [params.tpo, params.tpoSuitability, params.mood].filter(Boolean);
 
+  // ✨ 날짜 포맷 변환 (2026-06-01 -> 2026. 06. 01 (요일))
   let displayDate = params.date || '-';
-  if (params.date) {
+  if (params.date && /^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
     const dateObj = new Date(params.date);
     const days = ['일', '월', '화', '수', '목', '금', '토'];
-    const dayOfWeek = days[dateObj.getDay()];
-    // 하이픈(-)을 마침표(.)로 바꾸고 뒤에 요일 추가
-    displayDate = `${params.date.replace(/-/g, '.')} (${dayOfWeek})`; 
+    displayDate = `${params.date.replace(/-/g, '. ')} (${days[dateObj.getDay()]})`;
   }
 
   return (
@@ -48,6 +48,7 @@ export default function HistoryDetailScreen() {
       <SafeAreaView style={styles.container}>
         <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
           <View style={styles.headerArea}>
+            
             <View style={styles.dateRow}>
               <Ionicons name="calendar-clear-outline" size={26} color="#1E293B" />
               <Text style={styles.headerDate}>{displayDate}</Text>
@@ -65,7 +66,6 @@ export default function HistoryDetailScreen() {
               )}
             </View>
 
-            {/* ✨ 메모 영역: 아이콘과 함께 왼쪽 파란 선이 들어간 인용구 박스로 묶어 가독성 극대화 */}
             {params.memo && params.memo.trim() !== '' && (
               <View style={styles.memoContainer}>
                 <Ionicons name="chatbubble-ellipses" size={18} color="#3B82F6" />
@@ -80,19 +80,22 @@ export default function HistoryDetailScreen() {
             {clothes.length > 0 ? (
               clothes.map((cloth) => (
                 <View key={cloth.id} style={styles.clothCard}>
-                  <Text style={styles.clothName}>{cloth.name}</Text>
-                  
-                  <View style={styles.tagRow}>
-                    <Text style={styles.tagBadge}>{cloth.category}</Text>
-                    <Text style={styles.tagBadge}>{cloth.color || '색상 미상'}</Text>
-                  </View>
-                  
-                  {/* ✨ 옷 사진이 시원하게 보이도록 높이를 키움 */}
+                  {/* ✨ 1. 왼쪽에 정방형 썸네일 렌더링 */}
                   <Image 
-                    source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/300x300?text=No+Image' }} 
-                    style={styles.clothImage}
+                    source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/150x150?text=No+Img' }} 
+                    style={styles.clothThumbnail}
                     resizeMode="contain"
                   />
+                  
+                  {/* ✨ 2. 오른쪽에 옷 정보를 수직으로 정렬하여 배치 */}
+                  <View style={styles.clothInfo}>
+                    <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
+                    
+                    <View style={styles.tagRow}>
+                      <Text style={styles.tagBadge}>{cloth.category}</Text>
+                      <Text style={styles.tagBadge}>{cloth.color || '색상 미상'}</Text>
+                    </View>
+                  </View>
                 </View>
               ))
             ) : (
@@ -110,36 +113,12 @@ const styles = StyleSheet.create({
   content: { padding: 16, paddingBottom: 40 },
   
   headerArea: { paddingVertical: 10, marginBottom: 24, paddingHorizontal: 4 },
-
-  dateRow: { 
-    flexDirection: 'row', 
-    alignItems: 'center', 
-    gap: 8, 
-    marginBottom: 14 
-  },
+  dateRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 14 },
+  headerDate: { fontSize: 24, fontWeight: '700', color: '#1E293B' },
+  headerTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 18 },
+  headerTagChip: { backgroundColor: '#EEF2FF', paddingHorizontal: 14, paddingVertical: 7, borderRadius: 20 },
+  headerTagText: { fontSize: 13, fontWeight: '700', color: '#4F46E5' },
   
-  
-  headerDate: { 
-    fontSize: 24, 
-    fontWeight: '700', 
-    color: '#1E293B' 
-  },
-
-  headerTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
-  headerTagChip: { 
-    backgroundColor: '#EEF2FF',
-    paddingHorizontal: 14, 
-    paddingVertical: 7, 
-    borderRadius: 20 
-  },
-
-  headerTagText: { 
-    fontSize: 13, 
-    fontWeight: '700', 
-    color: '#4F46E5'
-  },
-  
-  // ✨ 메모 컨테이너 (인용구 스타일 박스)
   memoContainer: { 
     flexDirection: 'row',
     alignItems: 'flex-start',
@@ -154,16 +133,17 @@ const styles = StyleSheet.create({
 
   emptyText: { fontSize: 14, color: '#94A3B8' },
 
-  // ✨ 옷 섹션의 불필요한 회색 배경 제거하여 개방감 부여
   section: { marginBottom: 12 }, 
   sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 16, paddingHorizontal: 4 },
   
-  // ✨ 카드 스타일 고급화 (연한 테두리와 미세한 그림자)
+  // ✨ 가로형 레이아웃으로 변경된 카드 스타일
   clothCard: { 
+    flexDirection: 'row', // 가로 방향 배치
+    alignItems: 'center', // 세로 중앙 정렬
     backgroundColor: '#FFFFFF', 
     borderRadius: 16, 
     padding: 16, 
-    marginBottom: 16, 
+    marginBottom: 14, 
     borderWidth: 1, 
     borderColor: '#E2E8F0',
     shadowColor: '#000',
@@ -172,15 +152,28 @@ const styles = StyleSheet.create({
     shadowRadius: 8,
     elevation: 2
   },
-  clothName: { fontSize: 17, fontWeight: '800', color: '#1E293B', marginBottom: 10 },
-  tagRow: { flexDirection: 'row', gap: 6, marginBottom: 16 },
-  tagBadge: { backgroundColor: '#F1F5F9', color: '#475569', fontSize: 12, fontWeight: '700', paddingVertical: 6, paddingHorizontal: 10, borderRadius: 8 },
   
-  // ✨ 이미지 높이 대폭 확장
-  clothImage: {
-    width: '100%',
-    height: 280, 
+  clothThumbnail: {
+    width: 105,
+    height: 105,
     borderRadius: 12,
     backgroundColor: '#F8FAFC',
+    marginRight: 18, // 오른쪽 텍스트와의 간격
   },
+  
+  // ✨ 우측 텍스트 정보 영역
+  clothInfo: {
+    flex: 1, // 남은 공간을 모두 차지하도록 설정
+    justifyContent: 'center',
+  },
+
+  clothName: { 
+    fontSize: 17,
+    fontWeight: '800', 
+    color: '#1E293B', 
+    marginBottom: 10
+  },
+  
+  tagRow: { flexDirection: 'row', gap: 6 },
+  tagBadge: { backgroundColor: '#F1F5F9', color: '#475569', fontSize: 13, fontWeight: '700', paddingVertical: 6, paddingHorizontal: 10, borderRadius: 6 },
 });

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -1,13 +1,13 @@
+import { Ionicons } from '@expo/vector-icons';
 import { Stack, useLocalSearchParams } from 'expo-router';
-import { Image, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native'; // ✅ Image 컴포넌트 추가
+import { Image, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 
-// ✅ 백엔드에서 넘겨받을 이미지 URL 필드(imageUrl)를 타입에 추가
 type ClothingItem = {
   id: string;
   name: string;
   category: string;
   color: string;
-  imageUrl?: string; // ✅ 이미지 경로가 있을 경우를 위해 타입 추가
+  imageUrl?: string;
 };
 
 export default function HistoryDetailScreen() {
@@ -27,6 +27,15 @@ export default function HistoryDetailScreen() {
 
   const feedbackTags = [params.tpo, params.tpoSuitability, params.mood].filter(Boolean);
 
+  let displayDate = params.date || '-';
+  if (params.date) {
+    const dateObj = new Date(params.date);
+    const days = ['일', '월', '화', '수', '목', '금', '토'];
+    const dayOfWeek = days[dateObj.getDay()];
+    // 하이픈(-)을 마침표(.)로 바꾸고 뒤에 요일 추가
+    displayDate = `${params.date.replace(/-/g, '.')} (${dayOfWeek})`; 
+  }
+
   return (
     <>
       <Stack.Screen options={{ title: '착용 기록 상세' }} />
@@ -34,7 +43,10 @@ export default function HistoryDetailScreen() {
       <SafeAreaView style={styles.container}>
         <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
           <View style={styles.headerArea}>
-            <Text style={styles.headerDate}>{params.date || '-'}</Text>
+            <View style={styles.dateRow}>
+              <Ionicons name="calendar-clear-outline" size={26} color="#1E293B" />
+              <Text style={styles.headerDate}>{displayDate}</Text>
+            </View>
             
             <View style={styles.headerTagRow}>
               {feedbackTags.length > 0 ? (
@@ -48,7 +60,13 @@ export default function HistoryDetailScreen() {
               )}
             </View>
 
-            <Text style={styles.headerMemoText}>{params.memo || '입력된 메모가 없습니다.'}</Text>
+            {/* ✨ 메모 영역: 아이콘과 함께 왼쪽 파란 선이 들어간 인용구 박스로 묶어 가독성 극대화 */}
+            {params.memo && params.memo.trim() !== '' && (
+              <View style={styles.memoContainer}>
+                <Ionicons name="chatbubble-ellipses" size={18} color="#3B82F6" />
+                <Text style={styles.memoText}>{params.memo}</Text>
+              </View>
+            )}
           </View>
 
           <View style={styles.section}>
@@ -57,16 +75,14 @@ export default function HistoryDetailScreen() {
             {clothes.length > 0 ? (
               clothes.map((cloth) => (
                 <View key={cloth.id} style={styles.clothCard}>
-                  {/* 1. 옷 이름을 가장 돋보이게 위로 배치 */}
                   <Text style={styles.clothName}>{cloth.name}</Text>
                   
-                  {/* 2. 카테고리와 색상을 깔끔한 뱃지로 묶음 */}
                   <View style={styles.tagRow}>
                     <Text style={styles.tagBadge}>{cloth.category}</Text>
                     <Text style={styles.tagBadge}>{cloth.color || '색상 미상'}</Text>
                   </View>
                   
-                  {/* 3. 이미지는 가장 아래에 시원하게 배치 */}
+                  {/* ✨ 옷 사진이 시원하게 보이도록 높이를 키움 */}
                   <Image 
                     source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/300x300?text=No+Image' }} 
                     style={styles.clothImage}
@@ -87,56 +103,79 @@ export default function HistoryDetailScreen() {
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#fff' },
   content: { padding: 16, paddingBottom: 40 },
-  section: { backgroundColor: '#f7f7f7', borderRadius: 14, padding: 16, marginBottom: 12 },
-  sectionTitle: { fontSize: 14, fontWeight: '700', color: '#555', marginBottom: 8 },
   
   headerArea: { paddingVertical: 10, marginBottom: 24, paddingHorizontal: 4 },
-  headerDate: { fontSize: 28, fontWeight: '800', color: '#111', marginBottom: 12 },
-  headerTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 6, marginBottom: 16 },
-  headerTagChip: { backgroundColor: '#f1f5f9', paddingHorizontal: 12, paddingVertical: 6, borderRadius: 8 },
-  headerTagText: { fontSize: 13, fontWeight: '600', color: '#475569' },
-  headerMemoText: { fontSize: 15, color: '#334155', lineHeight: 24 },
+
+  dateRow: { 
+    flexDirection: 'row', 
+    alignItems: 'center', 
+    gap: 8, 
+    marginBottom: 14 
+  },
   
-  memoBox: { 
-    marginTop: 4, 
-    paddingTop: 16, 
-    borderTopWidth: 1, 
-    borderColor: '#eaeaea' 
-  },
-  memoText: { 
-    fontSize: 15, 
-    color: '#444', 
-    lineHeight: 22,
-    marginTop: 4
+  
+  headerDate: { 
+    fontSize: 24, 
+    fontWeight: '700', 
+    color: '#1E293B' 
   },
 
-  clothCard: { 
-    backgroundColor: '#fff', 
-    borderRadius: 12, 
+  headerTagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, marginBottom: 16 },
+  headerTagChip: { 
+    backgroundColor: '#EEF2FF',
+    paddingHorizontal: 14, 
+    paddingVertical: 7, 
+    borderRadius: 20 
+  },
+
+  headerTagText: { 
+    fontSize: 13, 
+    fontWeight: '700', 
+    color: '#4F46E5'
+  },
+  
+  // ✨ 메모 컨테이너 (인용구 스타일 박스)
+  memoContainer: { 
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    backgroundColor: '#F8FAFC', 
     padding: 16, 
-    marginTop: 12, 
+    borderRadius: 12, 
+    gap: 10,
+    borderLeftWidth: 4,
+    borderLeftColor: '#3B82F6', 
+  },
+  memoText: { fontSize: 15, color: '#334155', lineHeight: 24, flex: 1, fontWeight: '500' },
+
+  emptyText: { fontSize: 14, color: '#94A3B8' },
+
+  // ✨ 옷 섹션의 불필요한 회색 배경 제거하여 개방감 부여
+  section: { marginBottom: 12 }, 
+  sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 16, paddingHorizontal: 4 },
+  
+  // ✨ 카드 스타일 고급화 (연한 테두리와 미세한 그림자)
+  clothCard: { 
+    backgroundColor: '#FFFFFF', 
+    borderRadius: 16, 
+    padding: 16, 
+    marginBottom: 16, 
     borderWidth: 1, 
-    borderColor: '#ececec' 
+    borderColor: '#E2E8F0',
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 2 },
+    shadowOpacity: 0.03,
+    shadowRadius: 8,
+    elevation: 2
   },
-  clothName: { fontSize: 16, fontWeight: '700', color: '#222', marginBottom: 12 },
-
-  tagRow: { flexDirection: 'row', gap: 6, marginBottom: 12 },
-  tagBadge: { 
-    backgroundColor: '#f3f4f6', 
-    color: '#374151', 
-    fontSize: 12, 
-    fontWeight: '600', 
-    paddingVertical: 4, 
-    paddingHorizontal: 8, 
-    borderRadius: 6 
-  },
-
+  clothName: { fontSize: 17, fontWeight: '800', color: '#1E293B', marginBottom: 10 },
+  tagRow: { flexDirection: 'row', gap: 6, marginBottom: 16 },
+  tagBadge: { backgroundColor: '#F1F5F9', color: '#475569', fontSize: 12, fontWeight: '700', paddingVertical: 6, paddingHorizontal: 10, borderRadius: 8 },
+  
+  // ✨ 이미지 높이 대폭 확장
   clothImage: {
     width: '100%',
-    height: 220, // 이미지가 시원하게 보이도록 높이 설정
-    borderRadius: 8,
-    backgroundColor: '#f9f9f9',
+    height: 280, 
+    borderRadius: 12,
+    backgroundColor: '#F8FAFC',
   },
-
-  emptyText: { fontSize: 14, color: '#777' },
 });

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -25,6 +25,11 @@ export default function HistoryDetailScreen() {
     ? JSON.parse(params.clothes)
     : [];
 
+  clothes.sort((a, b) => {
+    const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
+    return (order[a.category] || 99) - (order[b.category] || 99);
+  });
+  
   const feedbackTags = [params.tpo, params.tpoSuitability, params.mood].filter(Boolean);
 
   let displayDate = params.date || '-';

--- a/ClosetApp/components/recommend/OutfitItemCard.tsx
+++ b/ClosetApp/components/recommend/OutfitItemCard.tsx
@@ -65,13 +65,34 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
 }
 
 const styles = StyleSheet.create({
-  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12 },
-  itemHeaderRow: { flexDirection: 'row', marginBottom: 10 },
-  itemBadge: { backgroundColor: '#F3F4F6', color: '#4B5563', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
-  itemImageContainer: { width: '100%', height: 200, backgroundColor: '#F3F4F6', borderRadius: 12, marginBottom: 12, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' },
+  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 12 },
+  itemHeaderRow: { flexDirection: 'row', marginBottom: 12 },
+  itemBadge: { backgroundColor: '#F1F5F9', color: '#475569', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
+  
+  itemImageContainer: { 
+    width: '100%', 
+    height: 280,
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12, 
+    marginBottom: 12, 
+    alignItems: 'center', 
+    justifyContent: 'center', 
+    overflow: 'hidden'
+  },
+
   itemImage: { width: '100%', height: '100%' },
-  imagePlaceholder: { width: '100%', height: 200, borderRadius: 12, backgroundColor: '#E5E7EB', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },
-  imagePlaceholderText: { fontSize: 13, color: '#6B7280', fontWeight: '600' },
-  itemName: { fontSize: 17, fontWeight: '800', color: '#111827', marginBottom: 10 },
+
+  imagePlaceholder: { 
+    width: '100%', 
+    height: 280, 
+    borderRadius: 12, 
+    backgroundColor: '#F8FAFC', 
+    alignItems: 'center', 
+    justifyContent: 'center', 
+    marginBottom: 12 
+  },
+  
+  imagePlaceholderText: { fontSize: 13, color: '#94A3B8', fontWeight: '600' },
+  itemName: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 12 },
   tagRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
 });

--- a/ClosetApp/components/recommend/OutfitItemCard.tsx
+++ b/ClosetApp/components/recommend/OutfitItemCard.tsx
@@ -65,10 +65,9 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
 }
 
 const styles = StyleSheet.create({
-  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12, borderWidth: 1, borderColor: '#EEF2F7' },
+  itemCard: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 12, marginBottom: 12 },
   itemHeaderRow: { flexDirection: 'row', marginBottom: 10 },
-  itemBadge: { backgroundColor: '#E8EEF9', color: '#2563EB', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
-  // ✨ Commit 1: 카드 리팩토링 (회색 배경 컨테이너 추가로 이미지와 카드 분리)
+  itemBadge: { backgroundColor: '#F3F4F6', color: '#4B5563', alignSelf: 'flex-start', paddingHorizontal: 10, paddingVertical: 6, borderRadius: 999, fontSize: 12, fontWeight: '700' },
   itemImageContainer: { width: '100%', height: 200, backgroundColor: '#F3F4F6', borderRadius: 12, marginBottom: 12, alignItems: 'center', justifyContent: 'center', overflow: 'hidden' },
   itemImage: { width: '100%', height: '100%' },
   imagePlaceholder: { width: '100%', height: 200, borderRadius: 12, backgroundColor: '#E5E7EB', alignItems: 'center', justifyContent: 'center', marginBottom: 12 },

--- a/ClosetApp/package-lock.json
+++ b/ClosetApp/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/vector-icons": "^15.0.3",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "8.4.4",
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
@@ -2777,6 +2778,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/ClosetApp/package.json
+++ b/ClosetApp/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",


### PR DESCRIPTION
## 작업 요약
착용 기록(History) 관련 전반적인 UI 고도화와 필수 버그 수정을 진행하였습니다.

## 주요 변경 사항

### UI/UX 강화
- **메인 리스트:** 날짜 우측에 태그를 배치하고, 메모를 감성적인 박스 형태로 시각화
- **필터링:** 캘린더를 통한 날짜 필터링 및 TPO별 필터링 연동
- **칩 스타일:** 피드백 태그(데일리/잘어울림 등)를 개별 칩으로 분리하여 가독성 확보
- **사용자 편의:** 기록 작성/수정 시 키보드 영역 확보 및 DatePicker 조작감 개선

### 버그 수정
- **날짜 수정 시 중복 데이터 생성 방지:** `POST` 후 기존 `DELETE` 로직 적용으로 데이터 무결성 확보
- **수정 모드 데이터 바인딩:** `expo-router` 파라미터 제한을 우회하는 ID 배열 전달 방식을 통해 옷 선택 상태 복구
- **입력 폼 개선:** `KeyboardAvoidingView` 적용 및 스크롤 처리로 입력 시 시야 확보

## 스크린샷 (기존 화면)
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5ee2fe37-2872-4f5d-b82b-39ce1bb9d540" /> 
<img width="250" alt="image" src="https://github.com/user-attachments/assets/636567ac-5cc9-4414-97a6-1c15ca4cd784" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/904ef314-bef5-49ad-9d89-c8567913f1cc" />

## 스크린샷 (개선 화면)
<img width="250"  alt="image" src="https://github.com/user-attachments/assets/9602f7d6-775a-4cd8-8ef1-dea90fa1bbac" />
<img width="250"  alt="image" src="https://github.com/user-attachments/assets/4cfb5fc7-b0b8-4b38-ae23-4d061960937b" />
<img width="250" alt="image" src="https://github.com/user-attachments/assets/0dd8c027-286f-4bef-bf0e-307f51bf4799" />

## 관련 이슈
- Closes #196