### PR TITLE
test: 통계(stats) 및 착용 기록(history) API 유닛 테스트 추가 및 유틸리티 테스트 픽스

### DIFF
--- a/backend/tests/test_history.py
+++ b/backend/tests/test_history.py
@@ -1,0 +1,14 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from datetime import date
+
+class TestHistory:
+    def test_착용기록_등록(self, client, auth_headers, sample_clothes):
+        clothes_id = sample_clothes[0]["clothes_id"]
+        res = client.post("/history", headers=auth_headers,
+                        json=[{"clothes_id": clothes_id, "worn_date": str(date.today())}])
+        assert res.status_code in (200, 201)
+
+    def test_착용기록_조회(self, client, auth_headers):
+        res = client.get("/history", headers=auth_headers)
+        assert res.status_code == 200

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -24,3 +24,15 @@ class TestStats:
         assert res.status_code == 200
         assert "best_efficiency" in res.json()
         assert "worst_efficiency" in res.json()
+
+    def test_옷장_과부하_분석(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/overload", headers=auth_headers)
+        assert res.status_code == 200
+        assert "total_warnings" in res.json()
+
+    def test_월간_리포트_통합_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/monthly-report", headers=auth_headers)
+        assert res.status_code == 200
+        data = res.json()
+        assert "ecosystem" in data
+        assert "overload" in data

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,13 @@
+import sys, os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+class TestStats:
+    def test_미착용_옷_우선순위_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/unworn?current_season=봄", headers=auth_headers)
+        assert res.status_code == 200
+        assert isinstance(res.json(), list)
+
+    def test_착용_빈도_통계_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/frequency", headers=auth_headers)
+        assert res.status_code == 200
+        assert isinstance(res.json(), list)

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -11,3 +11,16 @@ class TestStats:
         res = client.get("/stats/frequency", headers=auth_headers)
         assert res.status_code == 200
         assert isinstance(res.json(), list)
+
+
+    def test_처분_추천_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/dispose?current_season=봄", headers=auth_headers)
+        assert res.status_code == 200
+        assert "items" in res.json()
+        assert "ai_advice" in res.json()
+
+    def test_가성비_조회(self, client, auth_headers, sample_clothes):
+        res = client.get("/stats/cost-per-wear", headers=auth_headers)
+        assert res.status_code == 200
+        assert "best_efficiency" in res.json()
+        assert "worst_efficiency" in res.json()

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -9,10 +9,11 @@ from utils import (
     get_weather_data
 )
 
-pytestmark = pytest.mark.asyncio  # 해당 파일의 모든 테스트에 asyncio 마커 적용
+# 전역 마커(pytestmark) 삭제: 경고 제거. 필요한 곳에만 @pytest.mark.asyncio 부착.
 
+@pytest.mark.asyncio
 class TestGetCoordsFromAddress:
-    """1. OpenStreetMap 주소 -> 위경도 변환 테스트"""
+    """1. OpenStreetMap 주소 -> 위경도 변환 테스트 (비동기 함수)"""
     
     @patch('utils.httpx.AsyncClient')
     async def test_success(self, mock_async_client):
@@ -67,7 +68,7 @@ class TestGetCoordsFromAddress:
 
 
 class TestConvertGrid:
-    """2. 기상청 격자 변환(수학 연산) 테스트"""
+    """2. 기상청 격자 변환(수학 연산) 테스트 (동기 함수)"""
     
     def test_normal_grid(self):
         nx, ny = convert_grid(37.5665, 126.9780)
@@ -84,7 +85,7 @@ class TestConvertGrid:
 
 
 class TestGetBaseTime:
-    """3. 기상청 발표 시간 산출 로직 테스트"""
+    """3. 기상청 발표 시간 산출 로직 테스트 (동기 함수)"""
 
     @patch('utils.datetime')
     def test_normal_time(self, mock_datetime):
@@ -112,89 +113,103 @@ class TestGetBaseTime:
 
 
 class TestGetWeatherData:
-    """4. 기상청 단기예보 통신 및 날씨 분기 테스트"""
+    """4. 기상청 단기예보 통신 및 날씨 분기 테스트 (전면 동기 구조로 변경)"""
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
-    async def test_invalid_address(self, mock_get_coords):
-        mock_get_coords.return_value = (None, None)
-        res = await get_weather_data("이상한주소")
+    @patch('utils.requests.get')
+    def test_invalid_address(self, mock_requests_get):
+        # 위경도 변환 첫 번째 요청에서 실패(빈 배열 반환)
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = []
+        mock_requests_get.return_value = mock_geo_resp
+
+        res = get_weather_data("이상한주소")
         assert res == {"temperature": 20.0, "condition": "sunny"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_requests_exception(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
+    def test_requests_exception(self, mock_requests_get):
+        # 요청 중 서버 다운 등 Exception 발생
         mock_requests_get.side_effect = Exception("API Server Down")
         
-        res = await get_weather_data("서울")
+        res = get_weather_data("서울")
         assert res == {"temperature": 20.0, "condition": "sunny"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_resultcode_not_00(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"response": {"header": {"resultCode": "99"}}}
-        mock_requests_get.return_value = mock_resp
+    def test_resultcode_not_00(self, mock_requests_get):
+        # side_effect 배열: 1번째 호출은 주소, 2번째 호출은 날씨 API
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
         
-        res = await get_weather_data("서울")
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"response": {"header": {"resultCode": "99"}}}
+        
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
         assert res == {"temperature": 20.0, "condition": "sunny"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_weather_condition_rainy(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
+    def test_weather_condition_rainy(self, mock_requests_get):
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
             {"category": "TMP", "fcstValue": "15.0"},
             {"category": "SKY", "fcstValue": "4"},
             {"category": "PTY", "fcstValue": "1"}
         ]}}}}
-        mock_requests_get.return_value = mock_resp
         
-        res = await get_weather_data("서울")
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
         assert res == {"temperature": 15.0, "condition": "rainy"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_weather_condition_snowy(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
+    def test_weather_condition_snowy(self, mock_requests_get):
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
             {"category": "TMP", "fcstValue": "-2.0"},
             {"category": "SKY", "fcstValue": "4"},
             {"category": "PTY", "fcstValue": "3"}
         ]}}}}
-        mock_requests_get.return_value = mock_resp
         
-        res = await get_weather_data("서울")
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
         assert res == {"temperature": -2.0, "condition": "snowy"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_weather_condition_cloudy(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
+    def test_weather_condition_cloudy(self, mock_requests_get):
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
             {"category": "TMP", "fcstValue": "22.0"},
             {"category": "SKY", "fcstValue": "4"},
             {"category": "PTY", "fcstValue": "0"}
         ]}}}}
-        mock_requests_get.return_value = mock_resp
         
-        res = await get_weather_data("서울")
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
         assert res == {"temperature": 22.0, "condition": "cloudy"}
 
-    @patch('utils.get_coords_from_address', new_callable=AsyncMock)
     @patch('utils.requests.get')
-    async def test_weather_condition_missing_tmp(self, mock_requests_get, mock_get_coords):
-        mock_get_coords.return_value = (37.5, 126.9)
-        mock_resp = MagicMock()
-        mock_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
+    def test_weather_condition_missing_tmp(self, mock_requests_get):
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"response": {"header": {"resultCode": "00"}, "body": {"items": {"item": [
             {"category": "SKY", "fcstValue": "1"},
             {"category": "PTY", "fcstValue": "0"}
         ]}}}}
-        mock_requests_get.return_value = mock_resp
         
-        res = await get_weather_data("서울")
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
         assert res == {"temperature": 20.0, "condition": "sunny"}


### PR DESCRIPTION
## 📌 개요
통계/분석(stats) 및 착용 기록(history) API에 대한 유닛 테스트 코드를 신규 작성하고, 변경된 유틸리티 함수(`utils.py`) 구조에 맞춰 기존 테스트 코드의 모킹(Mocking) 로직을 정상화했습니다.

## 🛠️ 주요 작업 사항
**1. 신규 유닛 테스트 추가**
- `tests/test_stats.py`: 통계 및 분석 관련 6개 엔드포인트 테스트 코드 추가 (미착용 우선순위, 착용 빈도, 처분 추천, 가성비, 옷장 과부하, 월간 리포트)
- `tests/test_history.py`: 착용 기록 등록 및 조회 API 테스트 코드 추가

**2. `tests/test_utils.py` 테스트 코드 픽스**
- `get_weather_data`가 동기(Sync) 컨텍스트로 변경됨에 따라 관련 테스트 함수의 `await` 및 불필요한 비동기 마커 제거
- `requests.get` 연속 호출(지오코딩 -> 날씨 조회) 흐름에 맞게 모킹 대상 전면 수정
- 기존 `get_coords_from_address` 모킹을 제거하고 `requests.get`에 `side_effect`를 적용하여 실제 API 호출 오염 완벽 차단

## ✅ 테스트 결과
- 총 194개 유닛 테스트 100% 통과 (Coverage 93% 달성)