### PR TITLE
Refactor: 앱 전역 UI 디테일 폴리싱 및 SafeAreaView 경고 해결

### DIFF
--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -226,7 +226,7 @@ export default function HistoryScreen() {
             return (order[a.category] || 99) - (order[b.category] || 99);
           });
           
-          // ✨ 개별 태그 배열 생성
+          // 개별 태그 배열 생성
           const tags = [item.tpo, item.tpoSuitability, item.mood].filter((v) => v && v.trim() !== '');
           
           let displayDate = item.date;
@@ -240,7 +240,6 @@ export default function HistoryScreen() {
               <View style={styles.cardHeader}>
                 <Text style={styles.date}>{displayDate}</Text>
                 
-                {/* ✨ 쪼개진 태그 렌더링 */}
                 <View style={styles.tagWrapper}>
                   {tags.length > 0 ? (
                     tags.map((tag, index) => (
@@ -268,7 +267,6 @@ export default function HistoryScreen() {
                 ) : (<View style={styles.clothBox}><Text style={styles.clothName}>옷 정보 없음</Text></View>)}
               </ScrollView>
 
-              {/* ✨ 인용구 스타일의 메모 영역 */}
               {item.memo && item.memo.trim() !== '' && (
                 <View style={styles.memoBox}>
                   <Ionicons name="pencil" size={14} color="#4F46E5" style={{ marginTop: 2 }} />
@@ -323,7 +321,6 @@ const styles = StyleSheet.create({
   
   card: { backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 14, borderWidth: 1, borderColor: '#E2E8F0', shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.03, shadowRadius: 8, elevation: 2 },
   
-  // ✨ 카드 헤더 및 쪼개진 태그 스타일
   cardHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 },
   date: { fontSize: 16, fontWeight: '800', color: '#1E293B' },
   tagWrapper: { flexDirection: 'row', gap: 6, flexWrap: 'wrap', flex: 1, justifyContent: 'flex-end', marginLeft: 12 },
@@ -338,7 +335,6 @@ const styles = StyleSheet.create({
   clothName: { fontSize: 13, fontWeight: '700', color: '#334155', textAlign: 'center' },
   clothBox: { minHeight: 72, backgroundColor: '#fff', borderRadius: 10, padding: 12, justifyContent: 'center', borderWidth: 1, borderColor: '#eee' },
   
-  // ✨ 왼쪽 띠를 적용한 감성적인 메모 박스 스타일
   memoBox: { flexDirection: 'row', alignItems: 'flex-start', backgroundColor: '#F8FAFC', paddingVertical: 10, paddingHorizontal: 12, borderRadius: 8, gap: 8, marginTop: 8, borderLeftWidth: 3, borderLeftColor: '#4F46E5' },
   memoText: { fontSize: 13, color: '#334155', fontWeight: '500', lineHeight: 20, flex: 1 },
   

--- a/ClosetApp/app/(tabs)/history.tsx
+++ b/ClosetApp/app/(tabs)/history.tsx
@@ -9,13 +9,13 @@ import {
   Image,
   Platform,
   Pressable,
-  SafeAreaView,
   ScrollView,
   StatusBar,
   StyleSheet,
   Text,
   View
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import api from '../_api';
 

--- a/ClosetApp/app/(tabs)/recommend.tsx
+++ b/ClosetApp/app/(tabs)/recommend.tsx
@@ -140,7 +140,6 @@ export default function RecommendScreen() {
           <Ionicons name="arrow-back" size={28} color="#111827" />
         </TouchableOpacity>
         <Text style={[styles.title, { marginBottom: 0 }]}>코디 추천</Text>
-        {/* ✨ 스크린샷과 동일하게 👕 이모지 반영 */}
         <Text style={{ fontSize: 26 }}>👕</Text>
       </View>
 
@@ -149,7 +148,6 @@ export default function RecommendScreen() {
       {!apiRecommendations && (
         <View style={styles.section}>
           <View style={styles.sectionTitleRow}>
-            {/* ✨ ⛅ 이모지로 디자인 원복 */}
             <Text style={{ fontSize: 22 }}>⛅</Text>
             <Text style={styles.sectionTitle}>오늘의 날씨 기반 추천</Text>
           </View>
@@ -159,7 +157,6 @@ export default function RecommendScreen() {
           </View>
           
           <View style={styles.quickKeywordRow}>
-            {/* ✨ 추천 키워드 스크린샷과 동일하게 변경 */}
             {['데일리', '비즈니스', '데이트', '운동', '미팅'].map(keyword => (
               <TouchableOpacity key={keyword} style={styles.quickKeywordChip} onPress={() => setSituation(keyword)}>
                 <Text style={styles.quickKeywordText}>{keyword}</Text>
@@ -171,7 +168,6 @@ export default function RecommendScreen() {
             <Text style={styles.actionButtonText}>{apiLoading ? '불러오는 중...' : '코디 추천받기'}</Text>
           </TouchableOpacity>
 
-          {/* ✨ 삭제되었던 'AI 코디네이터 대기 중' 상태 완벽 복구 */}
           {apiLoading ? (
             <SkeletonLoader />
           ) : (
@@ -291,8 +287,6 @@ const styles = StyleSheet.create({
     lineHeight: 26, 
     fontWeight: '500'
   },
-  
-  // ✨ AI 대기 중 상태 박스 스타일 추가
   emptyStateBox: {
     alignItems: 'center',
     marginTop: 40,

--- a/ClosetApp/app/(tabs)/register.tsx
+++ b/ClosetApp/app/(tabs)/register.tsx
@@ -184,7 +184,6 @@ export default function RegisterScreen() {
     }
   };
 
-  // ✨ 수정 포인트: 가로 스크롤 뷰를 적용하여 세로 길이를 대폭 단축!
   const renderChips = <K extends keyof ClothesTags>(items: readonly string[], key: K) => (
     <View style={styles.chipRowWrapper}>
       <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipScrollContent}>
@@ -211,7 +210,6 @@ export default function RegisterScreen() {
         <Text style={[styles.title, { marginBottom: 0 }]}>옷 등록</Text>
       </View>
 
-      {/* ✨ 수정 포인트: 높이를 220 -> 160으로 줄이고 점선 테두리로 세련되게 변경 */}
       <TouchableOpacity style={styles.imageBox} onPress={pickImage} activeOpacity={0.8}>
         {image ? (
           <Image source={{ uri: image }} style={styles.image} resizeMode="contain" />
@@ -289,7 +287,6 @@ const styles = StyleSheet.create({
   headerRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
   title: { fontSize: 26, fontWeight: '800', color: '#111827' }, 
   
-  // ✨ 이미지 업로드 박스 디자인 및 크기 다이어트
   imageBox: { 
     height: 160, 
     borderRadius: 16, 
@@ -305,8 +302,7 @@ const styles = StyleSheet.create({
   placeholderWrap: { alignItems: 'center', gap: 8 },
   image: { width: '100%', height: '100%', backgroundColor: '#F8FAFC' },
   imagePlaceholder: { color: '#64748B', fontSize: 14, fontWeight: '600' },
-  
-  // ✨ 태그(Chip) 관련 타이틀 및 스타일 세련되게 변경
+
   sectionTitle: { fontSize: 14, fontWeight: '800', color: '#475569', marginTop: 16, marginBottom: 10, marginLeft: 2 },
   
   chipRowWrapper: { marginBottom: 6 },

--- a/ClosetApp/app/_api.ts
+++ b/ClosetApp/app/_api.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import { router } from 'expo-router';
 import { Alert } from 'react-native';
 
-// 백엔드 API 기본 주소 (기존과 동일)
+// 백엔드 API 기본 주소
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
 
 const api = axios.create({

--- a/ClosetApp/app/_closetStore.tsx
+++ b/ClosetApp/app/_closetStore.tsx
@@ -102,7 +102,7 @@ function normalizeClothesItem(raw: any): ClothesItem | null {
   return {
     id,
     name: raw.name || '이름 없음',
-    image: resolveImageUri(image), // ✅ 이미지 경로 정상화
+    image: resolveImageUri(image), // 이미지 경로 정상화
     createdAt: raw.created_at || raw.createdAt || new Date().toISOString(),
     tags: tags,
   };

--- a/ClosetApp/app/_layout.tsx
+++ b/ClosetApp/app/_layout.tsx
@@ -50,7 +50,6 @@ export default function RootLayout() {
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          {/* 🔐 새로 추가된 로그인 화면 (헤더 숨김) */}
           <Stack.Screen name="login" options={{ headerShown: false }} />
           <Stack.Screen name="detail" options={{ title: '옷 상세' }} />
           <Stack.Screen name="edit" options={{ title: '옷 수정' }} />

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -33,7 +33,6 @@ function resolveImageUri(image?: string | null) {
   return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
 }
 
-// ✨ 강력한 날짜 포맷 함수 (시간이 섞여 있어도 무조건 날짜만 추출)
 function formatDate(dateString?: string | null) {
   if (!dateString) return '';
   try {
@@ -121,7 +120,6 @@ export default function DetailScreen() {
     }
 
     const tagsArray = [
-      // 💡 옷 이름은 위로 단독 배치했으므로 여기서 뺐습니다!
       { label: '카테고리', value: s.category ?? item.category },
       { label: '색상', value: s.color ?? item.color }, 
       { label: '계절', value: s.season ?? item.season },
@@ -136,7 +134,6 @@ export default function DetailScreen() {
       { label: '누적 착용', value: `${wearCount}회` }, 
       { label: '구매가', value: priceValue },
       ...(showCost ? [{ label: '가성비', value: costPerWearStr, highlight: costHighlight }] : []),
-      // ✨ 변환 함수 적용 완료!
       { label: '마지막 착용일', value: formatDate(item.last_worn_date) },
     ];
     return tagsArray.filter((t) => t.value != null && String(t.value).trim() !== '');
@@ -166,7 +163,6 @@ export default function DetailScreen() {
           <View style={styles.imageFallback}><Text style={styles.imageFallbackText}>이미지가 없습니다.</Text></View>
         )}
 
-        {/* ✨ 새롭게 추가된 옷 이름 단독 노출 영역 */}
         <View style={styles.titleContainer}>
           <Text style={styles.mainItemName}>{item.name || '이름 없는 옷'}</Text>
         </View>
@@ -237,7 +233,6 @@ const styles = StyleSheet.create({
   imageFallback: { width: '100%', height: 260, borderRadius: 16, marginBottom: 16, backgroundColor: '#F8FAFC', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#E2E8F0' },
   imageFallbackText: { color: '#94A3B8', fontSize: 15, fontWeight: '600' },
   
-  // ✨ 옷 이름 타이틀 스타일 (새로 추가됨)
   titleContainer: { marginBottom: 24, paddingHorizontal: 4 },
   mainItemName: { fontSize: 24, fontWeight: '900', color: '#111827', letterSpacing: -0.5 },
 

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -1,9 +1,12 @@
-import { router, useFocusEffect, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { router, Stack, useFocusEffect, useLocalSearchParams } from 'expo-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Image,
+  Platform,
   ScrollView,
+  StatusBar,
   StyleSheet,
   Text,
   TouchableOpacity,
@@ -14,367 +17,223 @@ import api from './_api';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_URL ?? "http://localhost:8000";
 
-interface CareTip {
-  "세탁 및 관리": string;
-  "보관 방법": string;
-}
-
-interface TipResponse {
-  clothes_name: string;
-  material: string;
-  tip: CareTip | string;
-}
+interface CareTip { "세탁 및 관리": string; "보관 방법": string; }
+interface TipResponse { clothes_name: string; material: string; tip: CareTip | string; }
 
 type DetailApiItem = {
-  id?: number;
-  clothes_id?: number;
-  name?: string;
-  image?: string | null;
-  image_url?: string | null;
-  purchase_price?: number | null;
-  price?: number | null;
-  last_worn_date?: string | null;
-  wear_count?: number; // ✅ 가성비 계산을 위한 착용 횟수 필드 추가
-  situation?: string | null; 
-  tpo?: string | null;
-  tags?: {
-    category?: string;
-    color?: string;
-    season?: string;
-    tone?: string | null;
-    style?: string;
-    mood?: string | null;
-    material?: string | null;
-    thickness?: string | null;
-    point?: string | null;
-    situation?: string | null;
-    tpo?: string | null;
-    top_fit?: string | null;
-    bottom_fit?: string | null;
-    topFit?: string | null;
-    bottomFit?: string | null;
-  };
-  category?: string;
-  color?: string;
-  season?: string;
-  style?: string;
-  material?: string; 
+  id?: number; clothes_id?: number; name?: string; image?: string | null; image_url?: string | null;
+  purchase_price?: number | null; price?: number | null; last_worn_date?: string | null;
+  wear_count?: number; situation?: string | null; tpo?: string | null;
+  tags?: any; category?: string; color?: string; season?: string; style?: string; material?: string; 
 };
 
 function resolveImageUri(image?: string | null) {
   if (!image) return '';
-  if (image.startsWith('http://') || image.startsWith('https://') || image.startsWith('file://')) {
-    return image;
-  }
+  if (image.startsWith('http://') || image.startsWith('https://') || image.startsWith('file://')) return image;
   return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
 }
 
-// 뱃지 하이라이트 스타일을 위한 타입 정의
-type HighlightType = 'none' | 'good' | 'normal_cost' | 'warning';
+type HighlightType = 'none' | 'normal_cost' | 'warning';
 
 export default function DetailScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
-
   const [item, setItem] = useState<DetailApiItem | null>(null);
   const [loading, setLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
-
   const [tipData, setTipData] = useState<TipResponse | null>(null);
   const [tipLoading, setTipLoading] = useState(false);
 
   const fetchDetail = useCallback(async () => {
-    if (!id) {
-      setErrorMessage('옷 ID가 없습니다.');
-      setLoading(false);
-      return;
-    }
-
+    if (!id) { setErrorMessage('옷 ID가 없습니다.'); setLoading(false); return; }
     try {
-      setLoading(true);
-      setErrorMessage('');
-
+      setLoading(true); setErrorMessage('');
       const response = await api.get(`/clothes?t=${new Date().getTime()}`);
       const data: DetailApiItem[] = response.data;
-
-      const foundItem =
-        data.find((clothesItem) => String(clothesItem.id) === String(id)) ??
-        data.find((clothesItem) => String(clothesItem.clothes_id) === String(id)) ??
-        null;
-
-      if (!foundItem) {
-        setErrorMessage('데이터가 없습니다.');
-        setItem(null);
-        return;
-      }
-
+      const foundItem = data.find((c) => String(c.id) === String(id)) ?? data.find((c) => String(c.clothes_id) === String(id)) ?? null;
+      if (!foundItem) { setErrorMessage('데이터가 없습니다.'); setItem(null); return; }
       setItem(foundItem);
     } catch (error: any) {
-      console.error('옷 상세 불러오기 실패:', error);
-      if (error.response?.status === 401) {
-        setErrorMessage('로그인 세션이 만료되었습니다. 다시 로그인해주세요.');
-      } else {
-        setErrorMessage(error.response?.data?.detail || '상세 정보를 불러오지 못했습니다.');
-      }
+      setErrorMessage(error.response?.data?.detail || '상세 정보를 불러오지 못했습니다.');
       setItem(null);
     } finally {
       setLoading(false);
     }
   }, [id]);
 
-  useFocusEffect(
-    useCallback(() => {
-      fetchDetail();
-    }, [fetchDetail])
-  );
+  useFocusEffect(useCallback(() => { fetchDetail(); }, [fetchDetail]));
 
   useEffect(() => {
     const fetchCareTips = async () => {
       const actualId = item?.id ?? item?.clothes_id;
       if (!actualId) return;
-
       try {
         setTipLoading(true);
         const response = await api.get<TipResponse>(`/clothes/${actualId}/tips`);
         setTipData(response.data);
       } catch (error) {
-        console.error("소재별 관리 팁 로드 실패:", error);
         setTipData(null);
       } finally {
         setTipLoading(false);
       }
     };
-
     fetchCareTips();
   }, [item?.id, item?.clothes_id]);
 
   const visibleTags = useMemo(() => {
     if (!item) return [];
-
     const s = item.tags || {};
     const fitValue = s.top_fit ?? s.topFit ?? s.bottom_fit ?? s.bottomFit ?? '';
     const tpoValue = s.situation ?? s.tpo ?? item.situation ?? item.tpo ?? '';
-    
-    // 구매가 및 누적 착용 횟수 세팅
     const rawPrice = item.price ?? item.purchase_price;
     const wearCount = item.wear_count ?? 0;
+    const priceValue = (rawPrice != null) ? `${Number(rawPrice).toLocaleString()}원` : '';
     
-    const priceValue = (rawPrice !== null && rawPrice !== undefined)
-      ? `${Number(rawPrice).toLocaleString()}원` 
-      : '';
-
-    // ✅ 가성비(Cost per wear) 산출 로직 및 ZeroDivision 방어
     let costPerWearStr = '';
     let costHighlight: HighlightType = 'none';
     let showCost = false;
 
-    if (rawPrice !== null && rawPrice !== undefined && Number(rawPrice) > 0) {
+    if (rawPrice != null && Number(rawPrice) > 0) {
       showCost = true;
       if (wearCount === 0) {
-        // 착용 횟수가 0일 경우 (에러 방어)
+        // 미착용 시 빨간색 경고 표시
         costPerWearStr = '미착용 (계산 불가)';
         costHighlight = 'warning';
       } else {
-        // 정상 나눗셈 계산
+        // 착용 기록이 있으면 무조건 기존 사진의 연보라색 스타일 적용
         const costValue = Math.floor(Number(rawPrice) / wearCount);
         costPerWearStr = `₩${costValue.toLocaleString()} / 회`;
-        
-        // 1회당 비용이 10,000원 이하이면 초록색 뱃지로 '가성비 좋음' 강조
-        if (costValue <= 10000) {
-          costHighlight = 'good';
-        } else {
-          costHighlight = 'normal_cost';
-        }
+        costHighlight = 'normal_cost';
       }
     }
 
-    const tagsArray: Array<{ label: string; value: string | null | undefined; highlight?: HighlightType }> = [
-      { label: '이름', value: item.name },
-      { label: '카테고리', value: s.category ?? item.category },
-      { label: '색상', value: s.color ?? item.color },
-      { label: '계절', value: s.season ?? item.season },
-      { label: '톤', value: s.tone },
-      { label: '스타일', value: s.style ?? item.style },
-      { label: '분위기', value: s.mood },
-      { label: '핏', value: fitValue },
-      { label: '소재', value: s.material ?? item.material },
-      { label: '두께', value: s.thickness },
-      { label: '포인트', value: s.point },
-      { label: 'TPO', value: tpoValue },
-      { label: '누적 착용', value: `${wearCount}회` }, // 누적 착용 횟수 표기
-      { label: '구매가', value: priceValue },
-      // 조건부 가성비 항목 추가
+    const tagsArray = [
+      { label: '이름', value: item.name }, { label: '카테고리', value: s.category ?? item.category },
+      { label: '색상', value: s.color ?? item.color }, { label: '계절', value: s.season ?? item.season },
+      { label: '톤', value: s.tone }, { label: '스타일', value: s.style ?? item.style },
+      { label: '분위기', value: s.mood }, { label: '핏', value: fitValue },
+      { label: '소재', value: s.material ?? item.material }, { label: '두께', value: s.thickness },
+      { label: '포인트', value: s.point }, { label: 'TPO', value: tpoValue },
+      { label: '누적 착용', value: `${wearCount}회` }, { label: '구매가', value: priceValue },
       ...(showCost ? [{ label: '가성비', value: costPerWearStr, highlight: costHighlight }] : []),
       { label: '마지막 착용일', value: item.last_worn_date },
     ];
-
-    return tagsArray.filter(
-      (tag) =>
-        tag.value !== undefined &&
-        tag.value !== null &&
-        String(tag.value).trim() !== ''
-    );
+    return tagsArray.filter((t) => t.value != null && String(t.value).trim() !== '');
   }, [item]);
 
-  if (loading && !item) {
-    return (
-      <View style={styles.emptyContainer}>
-        <ActivityIndicator size="large" color="#111827" />
-        <Text style={styles.emptyText}>상세 정보를 불러오는 중...</Text>
-      </View>
-    );
-  }
-
-  if (!item) {
-    return (
-      <View style={styles.emptyContainer}>
-        <Text style={styles.emptyText}>{errorMessage || '데이터가 없습니다.'}</Text>
-      </View>
-    );
-  }
+  if (loading && !item) return <View style={styles.emptyContainer}><ActivityIndicator size="large" color="#2563EB" /></View>;
+  if (!item) return <View style={styles.emptyContainer}><Text style={styles.emptyText}>{errorMessage || '데이터가 없습니다.'}</Text></View>;
 
   const imageUri = resolveImageUri(item.image ?? item.image_url);
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      {imageUri ? (
-        <Image source={{ uri: imageUri }} style={styles.image} resizeMode="contain" />
-      ) : (
-        <View style={styles.imageFallback}>
-          <Text style={styles.imageFallbackText}>이미지가 없습니다.</Text>
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <StatusBar barStyle="dark-content" />
+        
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={10}>
+            <Ionicons name="arrow-back" size={28} color="#111827" />
+          </TouchableOpacity>
+          <Text style={[styles.title, { marginBottom: 0 }]}>옷 상세</Text>
         </View>
-      )}
 
-      <Text style={styles.sectionTitle}>선택된 태그</Text>
+        {imageUri ? (
+          <Image source={{ uri: imageUri }} style={styles.image} resizeMode="contain" />
+        ) : (
+          <View style={styles.imageFallback}><Text style={styles.imageFallbackText}>이미지가 없습니다.</Text></View>
+        )}
 
-      {visibleTags.length === 0 ? (
-        <Text style={styles.emptyTagText}>표시할 태그가 없습니다.</Text>
-      ) : (
-        <View style={styles.tagList}>
-          {visibleTags.map((tag) => {
-            // ✅ 가성비 뱃지 스타일 분기 처리
-            let pillStyle: any[] = [styles.tagPill];
-            let textStyle: any[] = [styles.tagText];
+        <Text style={styles.sectionTitle}>선택된 태그</Text>
 
-            if (tag.highlight === 'good') {
-              pillStyle.push(styles.goodCostPill);
-              textStyle.push(styles.goodCostText);
-            } else if (tag.highlight === 'normal_cost') {
-              pillStyle.push(styles.normalCostPill);
-              textStyle.push(styles.normalCostText);
-            } else if (tag.highlight === 'warning') {
-              pillStyle.push(styles.warningCostPill);
-              textStyle.push(styles.warningCostText);
-            }
+        {visibleTags.length === 0 ? (
+          <Text style={styles.emptyTagText}>표시할 태그가 없습니다.</Text>
+        ) : (
+          <View style={styles.tagList}>
+            {visibleTags.map((tag) => {
+              let pillStyle: any[] = [styles.tagPill];
+              let textStyle: any[] = [styles.tagText];
 
-            return (
-              <View key={`${tag.label}-${tag.value}`} style={styles.tagRow}>
-                <Text style={styles.tagLabel}>{tag.label}</Text>
-                <View style={pillStyle}>
-                  <Text style={textStyle}>{String(tag.value)}</Text>
+              if (tag.highlight === 'normal_cost') { pillStyle.push(styles.normalCostPill); textStyle.push(styles.normalCostText); }
+              else if (tag.highlight === 'warning') { pillStyle.push(styles.warningCostPill); textStyle.push(styles.warningCostText); }
+
+              return (
+                <View key={`${tag.label}-${tag.value}`} style={styles.tagRow}>
+                  <Text style={styles.tagLabel}>{tag.label}</Text>
+                  <View style={pillStyle}><Text style={textStyle}>{String(tag.value)}</Text></View>
                 </View>
-              </View>
-            );
-          })}
-        </View>
-      )}
+              );
+            })}
+          </View>
+        )}
 
-      {tipLoading ? (
-        <ActivityIndicator size="small" color="#111827" style={{ marginBottom: 20 }} />
-      ) : tipData ? (
-        <View style={styles.tipContainer}>
-          <Text style={styles.tipTitle}>💡 {tipData.material} 소재 관리 팁</Text>
-          
-          {typeof tipData.tip === 'object' ? (
-            <>
-              <View style={styles.tipBox}>
-                <Text style={styles.tipLabel}>🧼 세탁 및 관리</Text>
-                <Text style={styles.tipValueText}>{tipData.tip["세탁 및 관리"]}</Text>
-              </View>
-              <View style={styles.tipBox}>
-                <Text style={styles.tipLabel}>📦 보관 방법</Text>
-                <Text style={styles.tipValueText}>{tipData.tip["보관 방법"]}</Text>
-              </View>
-            </>
-          ) : (
-            <Text style={styles.errorTipText}>{tipData.tip}</Text>
-          )}
-        </View>
-      ) : null}
+        {tipLoading ? (
+          <ActivityIndicator size="small" color="#2563EB" style={{ marginBottom: 20 }} />
+        ) : tipData ? (
+          <View style={styles.tipContainer}>
+            <Text style={styles.tipTitle}>💡 {tipData.material} 소재 관리 팁</Text>
+            {typeof tipData.tip === 'object' ? (
+              <>
+                <View style={styles.tipBox}>
+                  <Text style={styles.tipLabel}>🧼 세탁 및 관리</Text>
+                  <Text style={styles.tipValueText}>{tipData.tip["세탁 및 관리"]}</Text>
+                </View>
+                <View style={styles.tipBox}>
+                  <Text style={styles.tipLabel}>📦 보관 방법</Text>
+                  <Text style={styles.tipValueText}>{tipData.tip["보관 방법"]}</Text>
+                </View>
+              </>
+            ) : (
+              <Text style={styles.errorTipText}>{tipData.tip}</Text>
+            )}
+          </View>
+        ) : null}
 
-      <TouchableOpacity
-        style={styles.button}
-        onPress={() => router.push({ 
-          pathname: '/edit', 
-          params: { id: String(item?.id ?? item?.clothes_id) } 
-        })}
-      >
-        <Text style={styles.buttonText}>수정하기</Text>
-      </TouchableOpacity>
-    </ScrollView>
+        <TouchableOpacity style={styles.button} activeOpacity={0.8} onPress={() => router.push({ pathname: '/edit', params: { id: String(item?.id ?? item?.clothes_id) } })}>
+          <Text style={styles.buttonText}>옷 정보 수정하기</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
-  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#fff', paddingHorizontal: 24 },
-  emptyText: { color: '#6b7280', fontSize: 15, marginTop: 12, textAlign: 'center' },
-  container: { flex: 1, backgroundColor: '#fff' },
-  content: { padding: 16, paddingBottom: 32 },
-  image: { width: '100%', height: 280, borderRadius: 16, marginBottom: 20, backgroundColor: '#f3f4f6' },
-  imageFallback: { width: '100%', height: 280, borderRadius: 16, marginBottom: 20, backgroundColor: '#f3f4f6', justifyContent: 'center', alignItems: 'center' },
-  imageFallbackText: { color: '#6b7280', fontSize: 15 },
-  sectionTitle: { fontSize: 20, fontWeight: '700', marginBottom: 12 },
-  emptyTagText: { color: '#6b7280', marginBottom: 20 },
-  tagList: { 
-    flexDirection: 'row', 
-    flexWrap: 'wrap', 
-    justifyContent: 'space-between', 
-    marginBottom: 20 
-  },
-  tagRow: { 
-    minWidth: '48%', // 화면의 절반씩 차지하게 설정 (2열 배치)
-    flexDirection: 'column', // 가로 폭이 좁아지므로 라벨은 위, 뱃지는 아래로 쌓이게 배치
-    alignItems: 'flex-start', 
-    marginBottom: 18, // 여백 살짝 조정
-    paddingRight: 8,
-  },
-
-  tagLabel: { 
-    fontSize: 13, 
-    color: '#6b7280', 
-    marginBottom: 6 
-  },
+  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#FFFFFF', paddingHorizontal: 24 },
+  emptyText: { color: '#64748B', fontSize: 15, marginTop: 12, textAlign: 'center' },
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  content: { padding: 20, paddingBottom: 40, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight! + 16 : 16 },
   
-  // 기본 태그 스타일
-  tagPill: { 
-    backgroundColor: '#f3f4f6', 
-    borderRadius: 999, 
-    paddingVertical: 8,
-    paddingHorizontal: 14 
-  },
-
-  tagText: { 
-    color: '#374151', 
-    fontSize: 15, 
-    fontWeight: '600' 
-  },
-
-  // ✅ 가성비 뱃지 추가 스타일
-  goodCostPill: { backgroundColor: '#dcfce7', borderWidth: 1, borderColor: '#bbf7d0' },
-  goodCostText: { color: '#166534', fontWeight: '800' }, // 뽕 뽑은 가성비 좋은 옷 (초록)
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
+  title: { fontSize: 26, fontWeight: '800', color: '#111827' },
   
-  normalCostPill: { backgroundColor: '#e0e7ff', borderWidth: 1, borderColor: '#c7d2fe' },
-  normalCostText: { color: '#3730a3', fontWeight: '700' }, // 일반 가성비 (파랑)
+  image: { width: '100%', height: 260, borderRadius: 16, marginBottom: 24, backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0' },
+  imageFallback: { width: '100%', height: 260, borderRadius: 16, marginBottom: 24, backgroundColor: '#F8FAFC', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#E2E8F0' },
+  imageFallbackText: { color: '#94A3B8', fontSize: 15, fontWeight: '600' },
   
-  warningCostPill: { backgroundColor: '#f3f4f6', borderWidth: 1, borderColor: '#e5e7eb' },
-  warningCostText: { color: '#6b7280', fontStyle: 'italic' }, // 미착용 상태 (회색)
+  sectionTitle: { fontSize: 18, fontWeight: '800', marginBottom: 16, color: '#111827' },
+  emptyTagText: { color: '#64748B', marginBottom: 20 },
+  
+  // ✨ 태그 리스트 디자인 복구 (둥근 알약 형태 및 사이즈 조정)
+  tagList: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between', marginBottom: 24 },
+  tagRow: { minWidth: '48%', flexDirection: 'column', alignItems: 'flex-start', marginBottom: 18, paddingRight: 8 },
+  tagLabel: { fontSize: 13, color: '#64748B', marginBottom: 6, fontWeight: '600', marginLeft: 4 },
+  
+  tagPill: { backgroundColor: '#F3F4F6', borderRadius: 999, paddingVertical: 8, paddingHorizontal: 16 },
+  tagText: { color: '#374151', fontSize: 14, fontWeight: '700' },
 
-  tipContainer: { backgroundColor: '#f9fafb', padding: 16, borderRadius: 12, marginBottom: 20, borderWidth: 1, borderColor: '#e5e7eb' },
-  tipTitle: { fontSize: 16, fontWeight: '700', marginBottom: 12, color: '#111827' },
-  tipBox: { marginBottom: 12 },
-  tipLabel: { fontSize: 14, fontWeight: '600', color: '#374151', marginBottom: 4 },
-  tipValueText: { fontSize: 14, color: '#4b5563', lineHeight: 20 },
-  errorTipText: { fontSize: 14, color: '#6b7280', fontStyle: 'italic', lineHeight: 20 },
+  // ✨ 가성비 태그 로직 색상 복구
+  normalCostPill: { backgroundColor: '#E0E7FF' }, // 기존 사진의 연보라/파랑 배경
+  normalCostText: { color: '#3730A3', fontWeight: '800' }, 
+  warningCostPill: { backgroundColor: '#FEF2F2' }, // 미착용 시 빨간 경고
+  warningCostText: { color: '#DC2626', fontWeight: '800' },
 
-  button: { marginTop: 8, backgroundColor: '#111827', paddingVertical: 16, borderRadius: 12, alignItems: 'center' },
-  buttonText: { color: '#fff', fontWeight: '700', fontSize: 16 },
+  tipContainer: { backgroundColor: '#F8FAFC', padding: 20, borderRadius: 16, marginBottom: 24, borderWidth: 1, borderColor: '#E2E8F0' },
+  tipTitle: { fontSize: 16, fontWeight: '800', marginBottom: 16, color: '#111827' },
+  tipBox: { marginBottom: 14 },
+  tipLabel: { fontSize: 14, fontWeight: '700', color: '#374151', marginBottom: 6 },
+  tipValueText: { fontSize: 14, color: '#475569', lineHeight: 22, fontWeight: '500' },
+  errorTipText: { fontSize: 14, color: '#94A3B8', fontStyle: 'italic', lineHeight: 22 },
+
+  button: { marginTop: 8, backgroundColor: '#2563EB', paddingVertical: 16, borderRadius: 12, alignItems: 'center' },
+  buttonText: { color: '#ffffff', fontWeight: '800', fontSize: 16, letterSpacing: 0.5 },
 });

--- a/ClosetApp/app/detail.tsx
+++ b/ClosetApp/app/detail.tsx
@@ -33,6 +33,22 @@ function resolveImageUri(image?: string | null) {
   return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
 }
 
+// ✨ 강력한 날짜 포맷 함수 (시간이 섞여 있어도 무조건 날짜만 추출)
+function formatDate(dateString?: string | null) {
+  if (!dateString) return '';
+  try {
+    // "2026-05-31T00:00:00" 같은 형태에서 "2026-05-31"만 잘라내기
+    const cleanDate = dateString.split('T')[0].split(' ')[0]; 
+    const parts = cleanDate.split('-');
+    if (parts.length === 3) {
+      return `${parts[0]}년 ${parseInt(parts[1], 10)}월 ${parseInt(parts[2], 10)}일`;
+    }
+  } catch (e) {
+    // 파싱 오류 발생 시 원본 반환
+  }
+  return dateString;
+}
+
 type HighlightType = 'none' | 'normal_cost' | 'warning';
 
 export default function DetailScreen() {
@@ -95,11 +111,9 @@ export default function DetailScreen() {
     if (rawPrice != null && Number(rawPrice) > 0) {
       showCost = true;
       if (wearCount === 0) {
-        // 미착용 시 빨간색 경고 표시
         costPerWearStr = '미착용 (계산 불가)';
         costHighlight = 'warning';
       } else {
-        // 착용 기록이 있으면 무조건 기존 사진의 연보라색 스타일 적용
         const costValue = Math.floor(Number(rawPrice) / wearCount);
         costPerWearStr = `₩${costValue.toLocaleString()} / 회`;
         costHighlight = 'normal_cost';
@@ -107,15 +121,23 @@ export default function DetailScreen() {
     }
 
     const tagsArray = [
-      { label: '이름', value: item.name }, { label: '카테고리', value: s.category ?? item.category },
-      { label: '색상', value: s.color ?? item.color }, { label: '계절', value: s.season ?? item.season },
-      { label: '톤', value: s.tone }, { label: '스타일', value: s.style ?? item.style },
-      { label: '분위기', value: s.mood }, { label: '핏', value: fitValue },
-      { label: '소재', value: s.material ?? item.material }, { label: '두께', value: s.thickness },
-      { label: '포인트', value: s.point }, { label: 'TPO', value: tpoValue },
-      { label: '누적 착용', value: `${wearCount}회` }, { label: '구매가', value: priceValue },
+      // 💡 옷 이름은 위로 단독 배치했으므로 여기서 뺐습니다!
+      { label: '카테고리', value: s.category ?? item.category },
+      { label: '색상', value: s.color ?? item.color }, 
+      { label: '계절', value: s.season ?? item.season },
+      { label: '톤', value: s.tone }, 
+      { label: '스타일', value: s.style ?? item.style },
+      { label: '분위기', value: s.mood }, 
+      { label: '핏', value: fitValue },
+      { label: '소재', value: s.material ?? item.material }, 
+      { label: '두께', value: s.thickness },
+      { label: '포인트', value: s.point }, 
+      { label: 'TPO', value: tpoValue },
+      { label: '누적 착용', value: `${wearCount}회` }, 
+      { label: '구매가', value: priceValue },
       ...(showCost ? [{ label: '가성비', value: costPerWearStr, highlight: costHighlight }] : []),
-      { label: '마지막 착용일', value: item.last_worn_date },
+      // ✨ 변환 함수 적용 완료!
+      { label: '마지막 착용일', value: formatDate(item.last_worn_date) },
     ];
     return tagsArray.filter((t) => t.value != null && String(t.value).trim() !== '');
   }, [item]);
@@ -143,6 +165,11 @@ export default function DetailScreen() {
         ) : (
           <View style={styles.imageFallback}><Text style={styles.imageFallbackText}>이미지가 없습니다.</Text></View>
         )}
+
+        {/* ✨ 새롭게 추가된 옷 이름 단독 노출 영역 */}
+        <View style={styles.titleContainer}>
+          <Text style={styles.mainItemName}>{item.name || '이름 없는 옷'}</Text>
+        </View>
 
         <Text style={styles.sectionTitle}>선택된 태그</Text>
 
@@ -206,14 +233,17 @@ const styles = StyleSheet.create({
   headerRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
   title: { fontSize: 26, fontWeight: '800', color: '#111827' },
   
-  image: { width: '100%', height: 260, borderRadius: 16, marginBottom: 24, backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0' },
-  imageFallback: { width: '100%', height: 260, borderRadius: 16, marginBottom: 24, backgroundColor: '#F8FAFC', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#E2E8F0' },
+  image: { width: '100%', height: 260, borderRadius: 16, marginBottom: 16, backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0' },
+  imageFallback: { width: '100%', height: 260, borderRadius: 16, marginBottom: 16, backgroundColor: '#F8FAFC', justifyContent: 'center', alignItems: 'center', borderWidth: 1, borderColor: '#E2E8F0' },
   imageFallbackText: { color: '#94A3B8', fontSize: 15, fontWeight: '600' },
   
+  // ✨ 옷 이름 타이틀 스타일 (새로 추가됨)
+  titleContainer: { marginBottom: 24, paddingHorizontal: 4 },
+  mainItemName: { fontSize: 24, fontWeight: '900', color: '#111827', letterSpacing: -0.5 },
+
   sectionTitle: { fontSize: 18, fontWeight: '800', marginBottom: 16, color: '#111827' },
   emptyTagText: { color: '#64748B', marginBottom: 20 },
   
-  // ✨ 태그 리스트 디자인 복구 (둥근 알약 형태 및 사이즈 조정)
   tagList: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'space-between', marginBottom: 24 },
   tagRow: { minWidth: '48%', flexDirection: 'column', alignItems: 'flex-start', marginBottom: 18, paddingRight: 8 },
   tagLabel: { fontSize: 13, color: '#64748B', marginBottom: 6, fontWeight: '600', marginLeft: 4 },
@@ -221,10 +251,9 @@ const styles = StyleSheet.create({
   tagPill: { backgroundColor: '#F3F4F6', borderRadius: 999, paddingVertical: 8, paddingHorizontal: 16 },
   tagText: { color: '#374151', fontSize: 14, fontWeight: '700' },
 
-  // ✨ 가성비 태그 로직 색상 복구
-  normalCostPill: { backgroundColor: '#E0E7FF' }, // 기존 사진의 연보라/파랑 배경
+  normalCostPill: { backgroundColor: '#E0E7FF' }, 
   normalCostText: { color: '#3730A3', fontWeight: '800' }, 
-  warningCostPill: { backgroundColor: '#FEF2F2' }, // 미착용 시 빨간 경고
+  warningCostPill: { backgroundColor: '#FEF2F2' }, 
   warningCostText: { color: '#DC2626', fontWeight: '800' },
 
   tipContainer: { backgroundColor: '#F8FAFC', padding: 20, borderRadius: 16, marginBottom: 24, borderWidth: 1, borderColor: '#E2E8F0' },

--- a/ClosetApp/app/edit.tsx
+++ b/ClosetApp/app/edit.tsx
@@ -1,10 +1,13 @@
-import { router, useLocalSearchParams } from 'expo-router';
+import { Ionicons } from '@expo/vector-icons';
+import { router, Stack, useLocalSearchParams } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   Image,
+  Platform,
   ScrollView,
+  StatusBar,
   StyleSheet,
   Text,
   TextInput,
@@ -23,17 +26,9 @@ function resolveImageUri(image?: string | null) {
   return image.startsWith('/') ? `${API_BASE_URL}${image}` : `${API_BASE_URL}/${image}`;
 }
 
-function Chip({
-  label,
-  selected,
-  onPress,
-}: {
-  label: string;
-  selected: boolean;
-  onPress: () => void;
-}) {
+function Chip({ label, selected, onPress }: { label: string; selected: boolean; onPress: () => void }) {
   return (
-    <TouchableOpacity onPress={onPress} style={[styles.chip, selected && styles.chipSelected]}>
+    <TouchableOpacity onPress={onPress} activeOpacity={0.7} style={[styles.chip, selected && styles.chipSelected]}>
       <Text style={[styles.chipText, selected && styles.chipTextSelected]}>{label}</Text>
     </TouchableOpacity>
   );
@@ -59,15 +54,12 @@ export default function EditScreen() {
         setLoading(false);
         return;
       }
-
       try {
         setLoading(true);
         const response = await api.get('/clothes');
         const data = Array.isArray(response.data) ? response.data : [];
 
-        const foundItem =
-          data.find((c: any) => String(c.id) === String(id)) ??
-          data.find((c: any) => String(c.clothes_id) === String(id));
+        const foundItem = data.find((c: any) => String(c.id) === String(id)) ?? data.find((c: any) => String(c.clothes_id) === String(id));
 
         if (!foundItem) {
           setErrorMessage('데이터가 없습니다.');
@@ -75,9 +67,7 @@ export default function EditScreen() {
           return;
         }
 
-        // ⭐ 핵심 수정: 계층화된 tags 객체에서 데이터를 먼저 찾도록 수정
         const s = foundItem.tags || {};
-
         setName(foundItem.name || '');
         setSelected({
           category: s.category || foundItem.category || '',
@@ -96,8 +86,6 @@ export default function EditScreen() {
 
         const rawPrice = foundItem.price ?? foundItem.purchase_price;
         setPrice(rawPrice != null ? String(rawPrice) : '');
-        
-        // 이미지 필드명 변경 대응 (image 우선)
         setImageUri(resolveImageUri(foundItem.image ?? foundItem.image_url));
 
       } catch (error: any) {
@@ -106,67 +94,45 @@ export default function EditScreen() {
         setLoading(false);
       }
     };
-
     fetchEditData();
   }, [id]);
 
   const toggleTag = <K extends keyof ClothesTags>(key: K, value: ClothesTags[K]) => {
     setSelected((prev) => {
       const next = prev[key] === value ? '' : value;
-      if (key === 'category') {
-        return { ...prev, category: next as ClothesTags['category'], topFit: '', bottomFit: '' };
-      }
+      if (key === 'category') return { ...prev, category: next as ClothesTags['category'], topFit: '', bottomFit: '' };
       return { ...prev, [key]: next };
     });
   };
 
   const renderChips = <K extends keyof ClothesTags>(items: readonly string[], key: K) => (
-    <View style={styles.chipWrap}>
-      {items.map((label) => (
-        <Chip
-          key={`${String(key)}-${label}`}
-          label={label}
-          selected={selected[key] === label}
-          onPress={() => toggleTag(key, label as ClothesTags[K])}
-        />
-      ))}
+    <View style={styles.chipRowWrapper}>
+      <ScrollView horizontal showsHorizontalScrollIndicator={false} contentContainerStyle={styles.chipScrollContent}>
+        {items.map((label) => (
+          <Chip key={`${String(key)}-${label}`} label={label} selected={selected[key] === label} onPress={() => toggleTag(key, label as ClothesTags[K])} />
+        ))}
+      </ScrollView>
     </View>
   );
 
   const handleSave = async () => {
-    if (!name.trim()) {
-      Alert.alert('입력 확인', '옷 이름을 입력해주세요.');
-      return;
-    }
-
+    if (!name.trim()) { Alert.alert('입력 확인', '옷 이름을 입력해주세요.'); return; }
     try {
       setSaveLoading(true);
-
       const updateData = {
-        name: name.trim(),
-        category: selected.category,
+        name: name.trim(), category: selected.category,
         top_fit: selected.category === '상의' ? (selected.topFit || null) : null,
         bottom_fit: selected.category === '하의' ? (selected.bottomFit || null) : null,
-        color: selected.color || null,
-        season: selected.season || null,
-        tone: selected.tone || null,
-        style: selected.style || null,
-        mood: selected.mood || null,
-        material: selected.material || null,
-        thickness: selected.thickness || null,
-        point: selected.point || null,
-        situation: selected.tpo || null, 
-        price: price ? Math.floor(Number(price)) : 0,
-        status: null, 
+        color: selected.color || null, season: selected.season || null, tone: selected.tone || null,
+        style: selected.style || null, mood: selected.mood || null, material: selected.material || null,
+        thickness: selected.thickness || null, point: selected.point || null, situation: selected.tpo || null, 
+        price: price ? Math.floor(Number(price)) : 0, status: null, 
       };
 
       await api.put(`/clothes/${id}`, updateData);
       await fetchClothes(); 
       updateClothes(String(id), { name, tags: selected });
-
-      Alert.alert('수정 완료', '성공적으로 수정되었습니다.', [
-        { text: '확인', onPress: () => router.back() }
-      ]);
+      Alert.alert('수정 완료', '성공적으로 수정되었습니다.', [{ text: '확인', onPress: () => router.back() }]);
     } catch (error: any) {
       Alert.alert('수정 실패', '데이터 형식을 확인해주세요.');
     } finally {
@@ -174,95 +140,78 @@ export default function EditScreen() {
     }
   };
 
-  if (loading) return <View style={styles.emptyContainer}><ActivityIndicator size="large" /></View>;
+  if (loading) return <View style={styles.emptyContainer}><ActivityIndicator size="large" color="#2563EB" /></View>;
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
-      <Text style={styles.title}>옷 수정</Text>
+    <>
+      <Stack.Screen options={{ headerShown: false }} />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+        <StatusBar barStyle="dark-content" />
+        
+        <View style={styles.headerRow}>
+          <TouchableOpacity onPress={() => router.back()} hitSlop={10}>
+            <Ionicons name="arrow-back" size={28} color="#111827" />
+          </TouchableOpacity>
+          <Text style={[styles.title, { marginBottom: 0 }]}>옷 수정</Text>
+        </View>
 
-      {imageUri ? (
-        <Image source={{ uri: imageUri }} style={styles.image} resizeMode="contain" />
-      ) : (
-        <View style={[styles.image, styles.center]}><Text style={{ color: '#9ca3af' }}>이미지 없음</Text></View>
-      )}
+        {imageUri ? (
+          <Image source={{ uri: imageUri }} style={styles.image} resizeMode="contain" />
+        ) : (
+          <View style={[styles.image, styles.center]}><Text style={{ color: '#94A3B8' }}>이미지 없음</Text></View>
+        )}
 
-      <Text style={styles.sectionTitle}>옷 이름</Text>
-      <TextInput style={styles.input} value={name} onChangeText={setName} placeholder="옷 이름" />
+        <Text style={styles.sectionTitle}>옷 이름</Text>
+        <TextInput style={styles.input} value={name} onChangeText={setName} placeholder="옷 이름" placeholderTextColor="#94A3B8" />
 
-      <Text style={styles.sectionTitle}>카테고리</Text>
-      {renderChips(TAG_OPTIONS.category, 'category')}
+        <Text style={styles.sectionTitle}>카테고리</Text>
+        {renderChips(TAG_OPTIONS.category, 'category')}
 
-      {selected.category === '상의' && (
-        <>
-          <Text style={styles.sectionTitle}>상의 핏</Text>
-          {renderChips(TAG_OPTIONS.topFit, 'topFit')}
-        </>
-      )}
+        {selected.category === '상의' && (
+          <><Text style={styles.sectionTitle}>상의 핏</Text>{renderChips(TAG_OPTIONS.topFit, 'topFit')}</>
+        )}
+        {selected.category === '하의' && (
+          <><Text style={styles.sectionTitle}>하의 핏</Text>{renderChips(TAG_OPTIONS.bottomFit, 'bottomFit')}</>
+        )}
 
-      {selected.category === '하의' && (
-        <>
-          <Text style={styles.sectionTitle}>하의 핏</Text>
-          {renderChips(TAG_OPTIONS.bottomFit, 'bottomFit')}
-        </>
-      )}
+        <Text style={styles.sectionTitle}>색상</Text>{renderChips(TAG_OPTIONS.color, 'color')}
+        <Text style={styles.sectionTitle}>계절</Text>{renderChips(TAG_OPTIONS.season, 'season')}
+        <Text style={styles.sectionTitle}>톤</Text>{renderChips(TAG_OPTIONS.tone, 'tone')}
+        <Text style={styles.sectionTitle}>스타일</Text>{renderChips(TAG_OPTIONS.style, 'style')}
+        <Text style={styles.sectionTitle}>분위기</Text>{renderChips(TAG_OPTIONS.mood, 'mood')}
+        <Text style={styles.sectionTitle}>소재</Text>{renderChips(TAG_OPTIONS.material, 'material')}
+        <Text style={styles.sectionTitle}>두께</Text>{renderChips(TAG_OPTIONS.thickness, 'thickness')}
+        <Text style={styles.sectionTitle}>포인트</Text>{renderChips(TAG_OPTIONS.point, 'point')}
+        <Text style={styles.sectionTitle}>TPO</Text>{renderChips(TAG_OPTIONS.tpo, 'tpo')}
 
-      <Text style={styles.sectionTitle}>색상</Text>
-      {renderChips(TAG_OPTIONS.color, 'color')}
+        <Text style={styles.sectionTitle}>구매가 수정</Text>
+        <TextInput style={styles.input} value={price} onChangeText={setPrice} keyboardType="numeric" placeholder="가격" placeholderTextColor="#94A3B8" />
 
-      <Text style={styles.sectionTitle}>계절</Text>
-      {renderChips(TAG_OPTIONS.season, 'season')}
-
-      <Text style={styles.sectionTitle}>톤</Text>
-      {renderChips(TAG_OPTIONS.tone, 'tone')}
-
-      <Text style={styles.sectionTitle}>스타일</Text>
-      {renderChips(TAG_OPTIONS.style, 'style')}
-
-      <Text style={styles.sectionTitle}>분위기</Text>
-      {renderChips(TAG_OPTIONS.mood, 'mood')}
-
-      <Text style={styles.sectionTitle}>소재</Text>
-      {renderChips(TAG_OPTIONS.material, 'material')}
-
-      <Text style={styles.sectionTitle}>두께</Text>
-      {renderChips(TAG_OPTIONS.thickness, 'thickness')}
-
-      <Text style={styles.sectionTitle}>포인트</Text>
-      {renderChips(TAG_OPTIONS.point, 'point')}
-
-      <Text style={styles.sectionTitle}>TPO</Text>
-      {renderChips(TAG_OPTIONS.tpo, 'tpo')}
-
-      <Text style={styles.sectionTitle}>구매가 수정</Text>
-      <TextInput style={styles.input} value={price} onChangeText={setPrice} keyboardType="numeric" placeholder="가격" />
-
-      <TouchableOpacity 
-        style={[styles.button, saveLoading && styles.disabledButton]} 
-        onPress={handleSave}
-        disabled={saveLoading}
-      >
-        <Text style={styles.buttonText}>{saveLoading ? '저장 중...' : '수정 완료'}</Text>
-      </TouchableOpacity>
-    </ScrollView>
+        <TouchableOpacity style={[styles.button, saveLoading && styles.disabledButton]} onPress={handleSave} disabled={saveLoading} activeOpacity={0.8}>
+          <Text style={styles.buttonText}>{saveLoading ? '저장 중...' : '수정 완료'}</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
-  // 스타일은 이전과 동일
-  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#fff' },
-  container: { flex: 1, backgroundColor: '#fff' },
-  content: { padding: 16, paddingBottom: 40 },
+  emptyContainer: { flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#FFFFFF' },
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  content: { padding: 20, paddingBottom: 40, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight! + 16 : 16 },
   center: { justifyContent: 'center', alignItems: 'center' },
-  title: { fontSize: 26, fontWeight: '700', marginBottom: 16 },
-  image: { width: '100%', height: 220, borderRadius: 16, marginBottom: 20, backgroundColor: '#f3f4f6' },
-  sectionTitle: { fontSize: 16, fontWeight: '700', marginTop: 14, marginBottom: 10 },
-  chipWrap: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 6 },
-  chip: { paddingVertical: 8, paddingHorizontal: 12, borderRadius: 999, backgroundColor: '#f3f4f6', marginRight: 8, marginBottom: 8 },
-  chipSelected: { backgroundColor: '#111827' },
-  chipText: { color: '#111827', fontSize: 13 },
-  chipTextSelected: { color: '#fff' },
-  input: { borderWidth: 1, borderColor: '#e5e7eb', borderRadius: 12, padding: 14, fontSize: 16, backgroundColor: '#f9fafb', color: '#111827', marginBottom: 16 },
-  button: { marginTop: 18, backgroundColor: '#111827', paddingVertical: 16, borderRadius: 12, alignItems: 'center' },
-  disabledButton: { opacity: 0.6 },
-  buttonText: { color: '#fff', fontWeight: '700', fontSize: 16 },
+  headerRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
+  title: { fontSize: 26, fontWeight: '800', color: '#111827' },
+  image: { width: '100%', height: 220, borderRadius: 16, marginBottom: 16, backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0' },
+  sectionTitle: { fontSize: 14, fontWeight: '800', color: '#475569', marginTop: 16, marginBottom: 10, marginLeft: 2 },
+  chipRowWrapper: { marginBottom: 6 },
+  chipScrollContent: { paddingRight: 20 },
+  chip: { paddingVertical: 10, paddingHorizontal: 16, borderRadius: 20, backgroundColor: '#F8FAFC', marginRight: 8, borderWidth: 1, borderColor: '#E2E8F0' },
+  chipSelected: { backgroundColor: '#EFF6FF', borderColor: '#3B82F6' },
+  chipText: { color: '#64748B', fontSize: 13, fontWeight: '600' },
+  chipTextSelected: { color: '#2563EB', fontWeight: '800' },
+  input: { borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 12, padding: 14, fontSize: 15, backgroundColor: '#F8FAFC', color: '#111827', marginBottom: 8, marginTop: 4 },
+  button: { marginTop: 24, backgroundColor: '#2563EB', paddingVertical: 16, borderRadius: 12, alignItems: 'center' },
+  disabledButton: { backgroundColor: '#94A3B8' },
+  buttonText: { color: '#ffffff', fontWeight: '800', fontSize: 16 },
 });

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -9,11 +9,12 @@ import {
   KeyboardAvoidingView,
   Platform,
   Pressable,
-  SafeAreaView,
   ScrollView,
+  StatusBar,
   StyleSheet,
   Text,
   TextInput,
+  TouchableOpacity,
   View,
 } from 'react-native';
 
@@ -198,23 +199,30 @@ export default function HistoryCreateScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ title: isEditMode ? '착용 기록 수정' : '착용 기록 추가' }} />
-      <SafeAreaView style={styles.container}>
-        {/* ✨ 키보드 회피 뷰 적용 */}
+      <Stack.Screen options={{ headerShown: false }} />
+      <View style={styles.container}>
+        <StatusBar barStyle="dark-content" />
         <KeyboardAvoidingView 
           style={{ flex: 1 }} 
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
           keyboardVerticalOffset={Platform.OS === 'ios' ? 80 : 0}
         >
           {loadingClothes ? (
-            <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111" /><Text style={styles.loadingText}>옷 목록 불러오는 중...</Text></View>
+            <View style={styles.loadingContainer}><ActivityIndicator size="large" color="#111827" /><Text style={styles.loadingText}>옷 목록 불러오는 중...</Text></View>
           ) : (
             <ScrollView 
               contentContainerStyle={styles.content} 
               showsVerticalScrollIndicator={false}
-              keyboardShouldPersistTaps="handled" // ✨ 키보드 열린 상태에서도 버튼 탭 유지
+              keyboardShouldPersistTaps="handled"
             >
               
+              <View style={styles.customHeaderRow}>
+                <TouchableOpacity onPress={() => router.back()} hitSlop={10}>
+                  <Ionicons name="arrow-back" size={28} color="#111827" />
+                </TouchableOpacity>
+                <Text style={styles.customHeaderTitle}>{isEditMode ? '착용 기록 수정' : '착용 기록 추가'}</Text>
+              </View>
+
               <View style={styles.section}>
                 <Text style={styles.sectionTitle}>날짜</Text>
                 <Pressable style={styles.dateBox} onPress={() => setShowDatePicker(true)}>
@@ -270,14 +278,18 @@ export default function HistoryCreateScreen() {
             </ScrollView>
           )}
         </KeyboardAvoidingView>
-      </SafeAreaView>
+      </View>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#fff' },
-  content: { padding: 16, paddingBottom: 60 },
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  content: { padding: 20, paddingBottom: 60, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight! + 16 : 16 },
+  
+  customHeaderRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
+  customHeaderTitle: { fontSize: 26, fontWeight: '800', color: '#111827', marginBottom: 0 },
+
   section: { marginBottom: 32 },
   sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 14 },
   dateBox: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#F8FAFC', padding: 16, borderRadius: 12, gap: 10, borderWidth: 1, borderColor: '#E2E8F0' },
@@ -296,13 +308,13 @@ const styles = StyleSheet.create({
   clothNameSelected: { color: '#4F46E5', fontWeight: '700' },
   chipRow: { flexDirection: 'row', flexWrap: 'wrap', gap: 8 },
   chip: { paddingHorizontal: 14, paddingVertical: 8, borderRadius: 18, backgroundColor: '#FFFFFF', borderWidth: 1, borderColor: '#E2E8F0' },
-  chipSelected: { backgroundColor: '#1E293B', borderColor: '#1E293B' },
+  chipSelected: { backgroundColor: '#111827', borderColor: '#111827' },
   chipText: { fontSize: 13, color: '#64748B', fontWeight: '600' },
   chipTextSelected: { color: '#FFFFFF' },
   input: { backgroundColor: '#F8FAFC', borderWidth: 1, borderColor: '#E2E8F0', borderRadius: 12, padding: 16, minHeight: 120, textAlignVertical: 'top', fontSize: 15, color: '#334155', lineHeight: 22 },
-  saveButton: { marginTop: 10, backgroundColor: '#111', paddingVertical: 16, borderRadius: 12, alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 6, elevation: 3 },
+  saveButton: { marginTop: 10, backgroundColor: '#2563EB', paddingVertical: 16, borderRadius: 12, alignItems: 'center', shadowColor: '#000', shadowOffset: { width: 0, height: 4 }, shadowOpacity: 0.1, shadowRadius: 6, elevation: 3 },
   saveButtonDisabled: { opacity: 0.5 },
-  saveText: { color: '#fff', fontSize: 17, fontWeight: '700' },
+  saveText: { color: '#ffffff', fontSize: 17, fontWeight: '800' },
   loadingContainer: { flex: 1, justifyContent: 'center', alignItems: 'center' },
   loadingText: { marginTop: 12, fontSize: 14, color: '#64748B' },
   mockWarningText: { fontSize: 13, color: '#EF4444', marginBottom: 12, fontWeight: '600' },

--- a/ClosetApp/app/history-create.tsx
+++ b/ClosetApp/app/history-create.tsx
@@ -179,16 +179,20 @@ export default function HistoryCreateScreen() {
       if (isEditMode) {
         const originalDate = params.editDate;
         if (originalDate && submitDate !== originalDate) {
-          await api.post('/history', payload);
           if (params.editHistoryIds) {
             const oldIds = JSON.parse(params.editHistoryIds);
-            for (const id of oldIds) await api.delete(`/history/${Number(id)}`);
+            for (const id of oldIds) {
+              await api.delete(`/history/${Number(id)}`);
           }
-        } else {
+        }
+        await api.post('/history', payload);
+      } else {
           await api.put(`/history`, payload); 
         }
         Alert.alert('수정 완료', '착용 기록이 수정되었습니다.', [{ text: '확인', onPress: () => router.replace('/(tabs)/history') }]);
-      } else {
+      }
+      
+      else {
         await api.post('/history', payload);
         Alert.alert('저장 완료', '착용 기록이 저장되었습니다.', [{ text: '확인', onPress: () => router.replace('/(tabs)/history') }]);
       }

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -41,7 +41,6 @@ export default function HistoryDetailScreen() {
 
   return (
     <>
-      {/* ✨ 까만 기본 헤더 숨기기 */}
       <Stack.Screen options={{ headerShown: false }} />
 
       <View style={styles.container}>

--- a/ClosetApp/app/history-detail.tsx
+++ b/ClosetApp/app/history-detail.tsx
@@ -1,6 +1,6 @@
 import { Ionicons } from '@expo/vector-icons';
-import { Stack, useLocalSearchParams } from 'expo-router';
-import { Image, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
+import { Image, Platform, ScrollView, StatusBar, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
 type ClothingItem = {
   id: string;
@@ -25,7 +25,6 @@ export default function HistoryDetailScreen() {
     ? JSON.parse(params.clothes)
     : [];
 
-  // ✨ 옷 카테고리 순서대로 정렬 (아우터 > 상의 > 하의 > 신발)
   clothes.sort((a, b) => {
     const order: Record<string, number> = { '아우터': 1, '상의': 2, '하의': 3, '신발': 4, '악세사리': 5, '기타': 6 };
     return (order[a.category] || 99) - (order[b.category] || 99);
@@ -33,7 +32,6 @@ export default function HistoryDetailScreen() {
 
   const feedbackTags = [params.tpo, params.tpoSuitability, params.mood].filter(Boolean);
 
-  // ✨ 날짜 포맷 변환 (2026-06-01 -> 2026. 06. 01 (요일))
   let displayDate = params.date || '-';
   if (params.date && /^\d{4}-\d{2}-\d{2}$/.test(params.date)) {
     const dateObj = new Date(params.date);
@@ -43,12 +41,21 @@ export default function HistoryDetailScreen() {
 
   return (
     <>
-      <Stack.Screen options={{ title: '착용 기록 상세' }} />
+      {/* ✨ 까만 기본 헤더 숨기기 */}
+      <Stack.Screen options={{ headerShown: false }} />
 
-      <SafeAreaView style={styles.container}>
+      <View style={styles.container}>
+        <StatusBar barStyle="dark-content" />
         <ScrollView contentContainerStyle={styles.content} showsVerticalScrollIndicator={false}>
+          
+          <View style={styles.customHeaderRow}>
+            <TouchableOpacity onPress={() => router.back()} hitSlop={10}>
+              <Ionicons name="arrow-back" size={28} color="#111827" />
+            </TouchableOpacity>
+            <Text style={styles.customHeaderTitle}>착용 기록 상세</Text>
+          </View>
+
           <View style={styles.headerArea}>
-            
             <View style={styles.dateRow}>
               <Ionicons name="calendar-clear-outline" size={26} color="#1E293B" />
               <Text style={styles.headerDate}>{displayDate}</Text>
@@ -80,17 +87,13 @@ export default function HistoryDetailScreen() {
             {clothes.length > 0 ? (
               clothes.map((cloth) => (
                 <View key={cloth.id} style={styles.clothCard}>
-                  {/* ✨ 1. 왼쪽에 정방형 썸네일 렌더링 */}
                   <Image 
                     source={{ uri: cloth.imageUrl || 'https://via.placeholder.com/150x150?text=No+Img' }} 
                     style={styles.clothThumbnail}
                     resizeMode="contain"
                   />
-                  
-                  {/* ✨ 2. 오른쪽에 옷 정보를 수직으로 정렬하여 배치 */}
                   <View style={styles.clothInfo}>
                     <Text style={styles.clothName} numberOfLines={1}>{cloth.name}</Text>
-                    
                     <View style={styles.tagRow}>
                       <Text style={styles.tagBadge}>{cloth.category}</Text>
                       <Text style={styles.tagBadge}>{cloth.color || '색상 미상'}</Text>
@@ -103,15 +106,18 @@ export default function HistoryDetailScreen() {
             )}
           </View>
         </ScrollView>
-      </SafeAreaView>
+      </View>
     </>
   );
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#fff' },
-  content: { padding: 16, paddingBottom: 40 },
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  content: { padding: 20, paddingBottom: 40, paddingTop: Platform.OS === 'android' ? StatusBar.currentHeight! + 16 : 16 },
   
+  customHeaderRow: { flexDirection: 'row', alignItems: 'center', gap: 10, marginBottom: 24 },
+  customHeaderTitle: { fontSize: 26, fontWeight: '800', color: '#111827', marginBottom: 0 },
+
   headerArea: { paddingVertical: 10, marginBottom: 24, paddingHorizontal: 4 },
   dateRow: { flexDirection: 'row', alignItems: 'center', gap: 8, marginBottom: 14 },
   headerDate: { fontSize: 24, fontWeight: '700', color: '#1E293B' },
@@ -119,16 +125,7 @@ const styles = StyleSheet.create({
   headerTagChip: { backgroundColor: '#EEF2FF', paddingHorizontal: 14, paddingVertical: 7, borderRadius: 20 },
   headerTagText: { fontSize: 13, fontWeight: '700', color: '#4F46E5' },
   
-  memoContainer: { 
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    backgroundColor: '#F8FAFC', 
-    padding: 16, 
-    borderRadius: 12, 
-    gap: 10,
-    borderLeftWidth: 4,
-    borderLeftColor: '#3B82F6', 
-  },
+  memoContainer: { flexDirection: 'row', alignItems: 'flex-start', backgroundColor: '#F8FAFC', padding: 16, borderRadius: 12, gap: 10, borderLeftWidth: 4, borderLeftColor: '#3B82F6' },
   memoText: { fontSize: 15, color: '#334155', lineHeight: 24, flex: 1, fontWeight: '500' },
 
   emptyText: { fontSize: 14, color: '#94A3B8' },
@@ -136,44 +133,10 @@ const styles = StyleSheet.create({
   section: { marginBottom: 12 }, 
   sectionTitle: { fontSize: 18, fontWeight: '800', color: '#111827', marginBottom: 16, paddingHorizontal: 4 },
   
-  // ✨ 가로형 레이아웃으로 변경된 카드 스타일
-  clothCard: { 
-    flexDirection: 'row', // 가로 방향 배치
-    alignItems: 'center', // 세로 중앙 정렬
-    backgroundColor: '#FFFFFF', 
-    borderRadius: 16, 
-    padding: 16, 
-    marginBottom: 14, 
-    borderWidth: 1, 
-    borderColor: '#E2E8F0',
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 2 },
-    shadowOpacity: 0.03,
-    shadowRadius: 8,
-    elevation: 2
-  },
-  
-  clothThumbnail: {
-    width: 105,
-    height: 105,
-    borderRadius: 12,
-    backgroundColor: '#F8FAFC',
-    marginRight: 18, // 오른쪽 텍스트와의 간격
-  },
-  
-  // ✨ 우측 텍스트 정보 영역
-  clothInfo: {
-    flex: 1, // 남은 공간을 모두 차지하도록 설정
-    justifyContent: 'center',
-  },
-
-  clothName: { 
-    fontSize: 17,
-    fontWeight: '800', 
-    color: '#1E293B', 
-    marginBottom: 10
-  },
-  
+  clothCard: { flexDirection: 'row', alignItems: 'center', backgroundColor: '#FFFFFF', borderRadius: 16, padding: 16, marginBottom: 14, borderWidth: 1, borderColor: '#E2E8F0', shadowColor: '#000', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.03, shadowRadius: 8, elevation: 2 },
+  clothThumbnail: { width: 105, height: 105, borderRadius: 12, backgroundColor: '#F8FAFC', marginRight: 18 },
+  clothInfo: { flex: 1, justifyContent: 'center' },
+  clothName: { fontSize: 17, fontWeight: '800', color: '#1E293B', marginBottom: 10 },
   tagRow: { flexDirection: 'row', gap: 6 },
   tagBadge: { backgroundColor: '#F1F5F9', color: '#475569', fontSize: 13, fontWeight: '700', paddingVertical: 6, paddingHorizontal: 10, borderRadius: 6 },
 });

--- a/ClosetApp/app/login.tsx
+++ b/ClosetApp/app/login.tsx
@@ -22,9 +22,8 @@ export default function LoginScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
-  const [isKeyboardVisible, setKeyboardVisible] = useState(false); // ✨ 키보드 상태 추가
+  const [isKeyboardVisible, setKeyboardVisible] = useState(false);
 
-  // ✨ 키보드가 올라오고 내려가는 이벤트를 감지하는 로직
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener(
       Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow',
@@ -136,7 +135,6 @@ export default function LoginScreen() {
               </TouchableOpacity>
             </View>
 
-            {/* ✨ 키보드가 안 보일 때만 푸터 렌더링 */}
             {!isKeyboardVisible && (
               <View style={styles.footer}>
                   <Text style={styles.footerText}>Powered by Gemini AI & FastAPI</Text>

--- a/ClosetApp/app/login.tsx
+++ b/ClosetApp/app/login.tsx
@@ -7,7 +7,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   TextInput,
@@ -15,6 +14,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import api from './_api';
 

--- a/ClosetApp/app/login.tsx
+++ b/ClosetApp/app/login.tsx
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { router } from 'expo-router';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
@@ -22,6 +22,24 @@ export default function LoginScreen() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [isKeyboardVisible, setKeyboardVisible] = useState(false); // ✨ 키보드 상태 추가
+
+  // ✨ 키보드가 올라오고 내려가는 이벤트를 감지하는 로직
+  useEffect(() => {
+    const keyboardDidShowListener = Keyboard.addListener(
+      Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow',
+      () => setKeyboardVisible(true)
+    );
+    const keyboardDidHideListener = Keyboard.addListener(
+      Platform.OS === 'android' ? 'keyboardDidHide' : 'keyboardWillHide',
+      () => setKeyboardVisible(false)
+    );
+
+    return () => {
+      keyboardDidHideListener.remove();
+      keyboardDidShowListener.remove();
+    };
+  }, []);
 
   const handleLogin = async () => {
     Keyboard.dismiss();
@@ -59,7 +77,6 @@ export default function LoginScreen() {
         >
           <View style={styles.content}>
             
-            {/* ✨ 브랜드 히어로 섹션 (PPT 느낌) */}
             <View style={styles.heroSection}>
               <Text style={styles.projectType}>Smart Closet Management System</Text>
               <View style={styles.brandRow}>
@@ -71,13 +88,12 @@ export default function LoginScreen() {
               <Text style={styles.heroSubtitle}>최적의 옷장 활용을 위한 AI 개인화 솔루션</Text>
             </View>
 
-            {/* 폼 섹션 */}
             <View style={styles.formCard}>
               <View style={styles.inputContainer}>
                 <TextInput
                   style={styles.input}
                   placeholder="Email Address"
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor="#94A3B8"
                   value={email}
                   onChangeText={setEmail}
                   autoCapitalize="none"
@@ -89,7 +105,7 @@ export default function LoginScreen() {
                 <TextInput
                   style={styles.input}
                   placeholder="Password"
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor="#94A3B8"
                   value={password}
                   onChangeText={setPassword}
                   secureTextEntry
@@ -103,7 +119,7 @@ export default function LoginScreen() {
                 activeOpacity={0.8}
               >
                 {loading ? (
-                  <ActivityIndicator color="#ffffff" />
+                  <ActivityIndicator color="#FFFFFF" />
                 ) : (
                   <Text style={styles.loginButtonText}>START SYSTEM</Text>
                 )}
@@ -120,10 +136,13 @@ export default function LoginScreen() {
               </TouchableOpacity>
             </View>
 
-            {/* 하단 푸터 느낌의 텍스트 */}
-            <View style={styles.footer}>
-                <Text style={styles.footerText}>Powered by Gemini AI & FastAPI</Text>
-            </View>
+            {/* ✨ 키보드가 안 보일 때만 푸터 렌더링 */}
+            {!isKeyboardVisible && (
+              <View style={styles.footer}>
+                  <Text style={styles.footerText}>Powered by Gemini AI & FastAPI</Text>
+              </View>
+            )}
+            
           </View>
         </KeyboardAvoidingView>
       </TouchableWithoutFeedback>
@@ -134,7 +153,7 @@ export default function LoginScreen() {
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#0f172a', // PPT 배경과 같은 딥 네이비
+    backgroundColor: '#FFFFFF', 
   },
   container: { 
     flex: 1, 
@@ -148,10 +167,10 @@ const styles = StyleSheet.create({
     marginBottom: 60,
   },
   projectType: {
-    fontSize: 14,
-    color: '#38bdf8', // 사이언 블루 포인트
-    fontWeight: '700',
-    letterSpacing: 1.5,
+    fontSize: 13,
+    color: '#2563EB', 
+    fontWeight: '800',
+    letterSpacing: 1.2,
     textTransform: 'uppercase',
     marginBottom: 8,
   },
@@ -161,69 +180,69 @@ const styles = StyleSheet.create({
   },
   brandName: {
     fontSize: 64,
-    fontWeight: '800',
-    color: '#FFFFFF',
+    fontWeight: '900',
+    color: '#111827',
     letterSpacing: -1,
   },
   brandColon: {
     fontSize: 64,
-    fontWeight: '800',
-    color: '#38bdf8',
+    fontWeight: '900',
+    color: '#2563EB',
   },
   brandAccent: {
     fontSize: 64,
-    fontWeight: '800',
-    color: '#FFFFFF',
+    fontWeight: '900',
+    color: '#111827',
     letterSpacing: -1,
   },
   decoLine: {
     width: 60,
     height: 4,
-    backgroundColor: '#38bdf8',
+    backgroundColor: '#2563EB',
     marginTop: 12,
     borderRadius: 2,
   },
   heroSubtitle: {
     fontSize: 16,
-    color: '#94a3b8',
+    color: '#64748B',
     marginTop: 20,
-    fontWeight: '500',
+    fontWeight: '600',
     lineHeight: 24,
   },
   formCard: {
     gap: 16,
   },
   inputContainer: {
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    backgroundColor: '#F8FAFC',
     borderRadius: 16,
     borderWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: '#E2E8F0',
     overflow: 'hidden',
   },
   input: {
     paddingHorizontal: 20,
     paddingVertical: 18,
     fontSize: 16,
-    color: '#FFFFFF',
+    color: '#111827',
   },
   loginButton: {
-    backgroundColor: '#38bdf8',
+    backgroundColor: '#2563EB',
     borderRadius: 16,
     paddingVertical: 20,
     alignItems: 'center',
     marginTop: 12,
-    shadowColor: '#38bdf8',
+    shadowColor: '#2563EB',
     shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.3,
+    shadowOpacity: 0.2,
     shadowRadius: 12,
-    elevation: 8,
+    elevation: 4,
   },
   loginButtonDisabled: {
-    backgroundColor: '#1e293b',
+    backgroundColor: '#94A3B8',
     shadowOpacity: 0,
   },
   loginButtonText: {
-    color: '#0f172a',
+    color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '800',
     letterSpacing: 1,
@@ -234,12 +253,12 @@ const styles = StyleSheet.create({
   },
   signupText: {
     fontSize: 14,
-    color: '#64748b',
+    color: '#64748B',
+    fontWeight: '500',
   },
   signupTextBold: {
-    color: '#38bdf8',
-    fontWeight: '700',
-    textDecorationLine: 'underline',
+    color: '#2563EB',
+    fontWeight: '800',
   },
   footer: {
     position: 'absolute',
@@ -250,7 +269,7 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 12,
-    color: '#334155',
+    color: '#94A3B8',
     fontWeight: '600',
     letterSpacing: 1,
   }

--- a/ClosetApp/app/signup.tsx
+++ b/ClosetApp/app/signup.tsx
@@ -1,17 +1,17 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { router } from 'expo-router';
-import { useState } from 'react';
+import { router, Stack } from 'expo-router'; // ✨ Stack 추가
+import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Alert,
   Keyboard,
   KeyboardAvoidingView,
   Platform,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
   TouchableOpacity,
-  TouchableWithoutFeedback,
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -23,6 +23,24 @@ export default function SignupScreen() {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [isKeyboardVisible, setKeyboardVisible] = useState(false);
+
+  // ✨ 키보드 활성화 상태 감지 로직
+  useEffect(() => {
+    const keyboardDidShowListener = Keyboard.addListener(
+      Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow',
+      () => setKeyboardVisible(true)
+    );
+    const keyboardDidHideListener = Keyboard.addListener(
+      Platform.OS === 'android' ? 'keyboardDidHide' : 'keyboardWillHide',
+      () => setKeyboardVisible(false)
+    );
+
+    return () => {
+      keyboardDidHideListener.remove();
+      keyboardDidShowListener.remove();
+    };
+  }, []);
 
   const handleSignup = async () => {
     Keyboard.dismiss();
@@ -56,15 +74,21 @@ export default function SignupScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea}>
-      <TouchableWithoutFeedback onPress={Keyboard.dismiss}>
+    <>
+      {/* ✨ 상단 'signup' 기본 헤더 바 숨김 처리 */}
+      <Stack.Screen options={{ headerShown: false }} />
+      
+      <SafeAreaView style={styles.safeArea}>
         <KeyboardAvoidingView 
           style={styles.container} 
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-          <View style={styles.content}>
-            
-            {/* ✨ 브랜드 히어로 섹션 (Login 화면과 통일) */}
+          {/* ✨ 스크롤 뷰를 적용하여 키보드가 올라와도 아래로 스크롤 가능하게 처리 */}
+          <ScrollView 
+            contentContainerStyle={styles.scrollContent}
+            showsVerticalScrollIndicator={false}
+            keyboardShouldPersistTaps="handled"
+          >
             <View style={styles.heroSection}>
               <Text style={styles.projectType}>Smart Closet Management System</Text>
               <View style={styles.brandRow}>
@@ -76,13 +100,12 @@ export default function SignupScreen() {
               <Text style={styles.heroSubtitle}>새로운 사용자를 위한 시스템 계정 등록</Text>
             </View>
 
-            {/* 회원가입 폼 섹션 */}
             <View style={styles.formCard}>
               <View style={styles.inputContainer}>
                 <TextInput
                   style={styles.input}
                   placeholder="Email Address"
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor="#94A3B8"
                   value={email}
                   onChangeText={setEmail}
                   autoCapitalize="none"
@@ -94,7 +117,7 @@ export default function SignupScreen() {
                 <TextInput
                   style={styles.input}
                   placeholder="Password"
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor="#94A3B8"
                   value={password}
                   onChangeText={setPassword}
                   secureTextEntry
@@ -105,7 +128,7 @@ export default function SignupScreen() {
                 <TextInput
                   style={styles.input}
                   placeholder="Confirm Password"
-                  placeholderTextColor="#94a3b8"
+                  placeholderTextColor="#94A3B8"
                   value={confirmPassword}
                   onChangeText={setConfirmPassword}
                   secureTextEntry
@@ -119,7 +142,7 @@ export default function SignupScreen() {
                 activeOpacity={0.8}
               >
                 {loading ? (
-                  <ActivityIndicator color="#ffffff" />
+                  <ActivityIndicator color="#FFFFFF" />
                 ) : (
                   <Text style={styles.signupButtonText}>계정 생성</Text>
                 )}
@@ -135,39 +158,44 @@ export default function SignupScreen() {
                 </Text>
               </TouchableOpacity>
             </View>
+          </ScrollView>
 
-            {/* 푸터 섹션 */}
+          {/* ✨ 키보드가 활성화되었을 때는 푸터 숨김 */}
+          {!isKeyboardVisible && (
             <View style={styles.footer}>
                 <Text style={styles.footerText}>Secure System Registration</Text>
             </View>
-          </View>
+          )}
+
         </KeyboardAvoidingView>
-      </TouchableWithoutFeedback>
-    </SafeAreaView>
+      </SafeAreaView>
+    </>
   );
 }
 
 const styles = StyleSheet.create({
   safeArea: {
     flex: 1,
-    backgroundColor: '#0f172a', // PPT 배경 색상
+    backgroundColor: '#FFFFFF',
   },
   container: { 
     flex: 1, 
   },
-  content: {
-    flex: 1,
+  scrollContent: {
+    flexGrow: 1,
     paddingHorizontal: 32,
     justifyContent: 'center',
+    paddingTop: 40,
+    paddingBottom: 100, // ✨ 여유 공간을 주어 스크롤 시 버튼이 넉넉하게 보이도록 함
   },
   heroSection: {
-    marginBottom: 48, // 입력창이 3개라 로그인보다는 조금 줄임
+    marginBottom: 48, 
   },
   projectType: {
-    fontSize: 14,
-    color: '#38bdf8',
-    fontWeight: '700',
-    letterSpacing: 1.5,
+    fontSize: 13,
+    color: '#2563EB',
+    fontWeight: '800',
+    letterSpacing: 1.2,
     textTransform: 'uppercase',
     marginBottom: 8,
   },
@@ -176,69 +204,69 @@ const styles = StyleSheet.create({
     alignItems: 'baseline',
   },
   brandName: {
-    fontSize: 56, // 입력창 공간 확보를 위해 약간 줄임
-    fontWeight: '800',
-    color: '#FFFFFF',
+    fontSize: 56, 
+    fontWeight: '900',
+    color: '#111827',
     letterSpacing: -1,
   },
   brandColon: {
     fontSize: 56,
-    fontWeight: '800',
-    color: '#38bdf8',
+    fontWeight: '900',
+    color: '#2563EB',
   },
   brandAccent: {
     fontSize: 56,
-    fontWeight: '800',
-    color: '#FFFFFF',
+    fontWeight: '900',
+    color: '#111827',
     letterSpacing: -1,
   },
   decoLine: {
     width: 60,
     height: 4,
-    backgroundColor: '#38bdf8',
+    backgroundColor: '#2563EB',
     marginTop: 12,
     borderRadius: 2,
   },
   heroSubtitle: {
     fontSize: 16,
-    color: '#94a3b8',
+    color: '#64748B',
     marginTop: 16,
-    fontWeight: '500',
+    fontWeight: '600',
   },
   formCard: {
     gap: 14,
   },
   inputContainer: {
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+    backgroundColor: '#F8FAFC',
     borderRadius: 16,
     borderWidth: 1,
-    borderColor: 'rgba(255, 255, 255, 0.1)',
+    borderColor: '#E2E8F0',
     overflow: 'hidden',
   },
   input: {
     paddingHorizontal: 20,
     paddingVertical: 18,
     fontSize: 16,
-    color: '#FFFFFF',
+    color: '#111827',
   },
   signupButton: {
-    backgroundColor: '#38bdf8',
+    backgroundColor: '#2563EB',
     borderRadius: 16,
     paddingVertical: 20,
     alignItems: 'center',
     marginTop: 12,
-    shadowColor: '#38bdf8',
+    shadowColor: '#2563EB',
     shadowOffset: { width: 0, height: 8 },
-    shadowOpacity: 0.3,
+    shadowOpacity: 0.2,
     shadowRadius: 12,
-    elevation: 8,
+    elevation: 4,
   },
   signupButtonDisabled: {
-    backgroundColor: '#1e293b',
+    backgroundColor: '#94A3B8',
     shadowOpacity: 0,
   },
   signupButtonText: {
-    color: '#0f172a',
+    color: '#FFFFFF',
     fontSize: 16,
     fontWeight: '800',
     letterSpacing: 1,
@@ -249,12 +277,12 @@ const styles = StyleSheet.create({
   },
   loginLinkText: {
     fontSize: 14,
-    color: '#64748b',
+    color: '#64748B',
+    fontWeight: '500',
   },
   loginLinkTextBold: {
-    color: '#38bdf8',
-    fontWeight: '700',
-    textDecorationLine: 'underline',
+    color: '#2563EB',
+    fontWeight: '800',
   },
   footer: {
     position: 'absolute',
@@ -265,7 +293,7 @@ const styles = StyleSheet.create({
   },
   footerText: {
     fontSize: 12,
-    color: '#334155',
+    color: '#94A3B8',
     fontWeight: '600',
     letterSpacing: 1,
     textTransform: 'uppercase',

--- a/ClosetApp/app/signup.tsx
+++ b/ClosetApp/app/signup.tsx
@@ -1,5 +1,5 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { router, Stack } from 'expo-router'; // ✨ Stack 추가
+import { router, Stack } from 'expo-router';
 import { useEffect, useState } from 'react';
 import {
   ActivityIndicator,
@@ -25,7 +25,6 @@ export default function SignupScreen() {
   const [loading, setLoading] = useState(false);
   const [isKeyboardVisible, setKeyboardVisible] = useState(false);
 
-  // ✨ 키보드 활성화 상태 감지 로직
   useEffect(() => {
     const keyboardDidShowListener = Keyboard.addListener(
       Platform.OS === 'android' ? 'keyboardDidShow' : 'keyboardWillShow',
@@ -75,7 +74,6 @@ export default function SignupScreen() {
 
   return (
     <>
-      {/* ✨ 상단 'signup' 기본 헤더 바 숨김 처리 */}
       <Stack.Screen options={{ headerShown: false }} />
       
       <SafeAreaView style={styles.safeArea}>
@@ -83,7 +81,6 @@ export default function SignupScreen() {
           style={styles.container} 
           behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
         >
-          {/* ✨ 스크롤 뷰를 적용하여 키보드가 올라와도 아래로 스크롤 가능하게 처리 */}
           <ScrollView 
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
@@ -160,7 +157,6 @@ export default function SignupScreen() {
             </View>
           </ScrollView>
 
-          {/* ✨ 키보드가 활성화되었을 때는 푸터 숨김 */}
           {!isKeyboardVisible && (
             <View style={styles.footer}>
                 <Text style={styles.footerText}>Secure System Registration</Text>
@@ -186,7 +182,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 32,
     justifyContent: 'center',
     paddingTop: 40,
-    paddingBottom: 100, // ✨ 여유 공간을 주어 스크롤 시 버튼이 넉넉하게 보이도록 함
+    paddingBottom: 100,
   },
   heroSection: {
     marginBottom: 48, 

--- a/ClosetApp/app/signup.tsx
+++ b/ClosetApp/app/signup.tsx
@@ -7,7 +7,6 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
-  SafeAreaView,
   StyleSheet,
   Text,
   TextInput,
@@ -15,6 +14,7 @@ import {
   TouchableWithoutFeedback,
   View,
 } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import api from './_api';
 

--- a/ClosetApp/components/recommend/OutfitItemCard.tsx
+++ b/ClosetApp/components/recommend/OutfitItemCard.tsx
@@ -1,4 +1,4 @@
-import { router } from 'expo-router'; // 라우터 추가
+import { router } from 'expo-router';
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { ClothesItem } from '../../app/_closetStore';
 import { TagChip } from './TagChip';
@@ -29,7 +29,6 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
   };
 
   return (
-    // ✨ Commit 3: 상세 보기 연결 (TouchableOpacity 추가)
     <TouchableOpacity activeOpacity={0.7} onPress={handlePress}>
       <View style={styles.itemCard}>
         <View style={styles.itemHeaderRow}>
@@ -38,7 +37,6 @@ export function OutfitItemCard({ label, item }: { label: string; item?: ClothesI
 
         {item.image ? (
           <View style={styles.itemImageContainer}>
-            {/* ✨ Commit 1: 이미지 비율 조정 (contain 유지) */}
             <Image 
               source={{ uri: resolveImageUri(item.image) }} 
               style={styles.itemImage} 


### PR DESCRIPTION
## 작업 내용
- **상세 화면 UI 디테일 강화**: 옷 이름을 메인 타이틀로 격상시키고, 날짜 포맷을 감성적으로 변경했습니다. 또한 태그 디자인을 둥근 형태로 되돌리고 가성비 컬러(착용 유무에 따른 동적 컬러)를 적용해 가독성을 높였습니다.

- **착용 기록 헤더 통일**: `history` 관련 화면들에 남아있던 블랙 네이티브 헤더를 걷어내고, 커스텀 헤더를 이식하여 화면 이동 간의 이질감을 완전히 제거했습니다.

- **Warning 클린업**: React Native 최신 아키텍처 대응을 위해 구형 `SafeAreaView` 코드를 `react-native-safe-area-context`로 전면 교체하여 터미널 경고를 말끔히 해결했습니다.

## 기존 옷 상세 화면 / 수정 화면
<img width="350" alt="image" src="https://github.com/user-attachments/assets/bb9dc461-bb68-493b-9478-bc7e0e3bb401" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/a9c76b00-f198-470b-9b4c-fa5442f2ce95" />

## 개선 옷 상세 화면 / 수정 화면
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c8776748-b970-4bed-b32e-c18abe09fc82" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/c3ce01a4-ea43-4c1c-9372-8a4d517edd8a" />

## 참고/공지 사항
- 본 PR은 기존에 작성된 '로그인/회원가입 디자인 수정 PR(#202)의 코드 변경 사항을 모두 포함하고 있습니다.

- 이번에 진행된 SafeAreaView 전역 마이그레이션 작업이 로그인/회원가입 파일에도 영향을 미치기 때문에, 발생할 수 있는 코드 충돌(Merge Conflict)을 사전에 방지하고자 하나의 브랜치로 통합하여 올립니다.

- 리뷰어님들은 기존 PR(#202) 대신 이 PR 하나만 리뷰하고 Merge 해주시면 됩니다.

## 관련 이슈
- Resolves #201
- Resolves #206 