### PR TITLE
fix: AI 추천 프롬프트에 신발 카테고리 포함 (#209)

### DIFF
--- a/backend/routers/recommend.py
+++ b/backend/routers/recommend.py
@@ -230,7 +230,7 @@ def build_prompt(clothes_list: list[Clothes], situation: str, temperature: float
 {clothes_text}
 [추천 규칙]
 1. 반드시 보유한 옷 ID만 사용하세요 (목록에 없는 ID 절대 사용 금지)
-2. 코디는 상의 1개 + 하의 1개 조합이 기본이며, 체감온도 {outer_threshold}°C 이하면 아우터 추가
+2. 코디는 상의 1개 + 하의 1개 + 신발 1개 조합이 기본이며, 체감온도 {outer_threshold}°C 이하면 아우터 추가
 3. 미착용 기간이 긴 옷을 우선 포함하세요
 4. 색 조합이 자연스러워야 합니다 (무채색 베이스 선호)
 5. {situation_kr} 상황과 사용자 선호 스타일({preferred_style})에 맞게 선택하세요
@@ -431,7 +431,7 @@ def recommend_weekly(
 - 상황: {situation_kr}
 [추천 규칙]
 1. 반드시 보유한 옷 ID만 사용하세요
-2. 코디는 상의 1개 + 하의 1개 조합이 기본이며, 기온 14°C 이하면 아우터 추가
+2. 코디는 상의 1개 + 하의 1개 + 신발 1개 조합이 기본이며, 기온 14°C 이하면 아우터 추가
 3. items 배열이 절대 비어있으면 안 됩니다
 4. reason은 반드시 한국어 2~3문장으로 작성하세요
 [보유 옷]


### PR DESCRIPTION
## 변경 사항
- `build_prompt` 함수의 추천 규칙 2번: "상의 1개 + 하의 1개" → "상의 1개 + 하의 1개 + 신발 1개"
- `recommend_weekly` 인라인 프롬프트 동일하게 수정

## 원인
AI 프롬프트 규칙이 상의+하의 조합만 명시되어 있어, 신발 데이터가 옷장에 존재해도 AI 응답에서 제외되는 문제

## 관련 이슈
Closes #209