### PR TITLE
UnitTest 테스트 파일 업데이트

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## 🛠 기술 스택
 Backend: Python + FastAPI
-Frontend: JavaScript, React Native + Expo
+Frontend: TypeScript, React Native + Expo
 Database: SQLite
 AI: Google Gemini 1.5 Flash API
 
@@ -24,7 +24,7 @@ AI: Google Gemini 1.5 Flash API
 Python 3.11+
 Node.js 18+
 pip 24+
-이 외 requrements.txt 명시
+이 외 requirements.txt 명시
 ```
 
 ## 💾 설치 방법
@@ -35,6 +35,11 @@ GEMINI_API_KEY=발급받은키입력
 WEATHER_SERVICE_KEY=발급받은키입력
 DATABASE_URL=sqlite:///./closet.db
 SECRET_KEY=mysecretkey123
+```
+
+ClosetApp 폴더에 .env 파일 생성 후 아래 내용 입력(에뮬레이터는 localhost, 실기기는 본인 IP 입력)
+```
+EXPO_PUBLIC_API_URL=http://localhost:8000
 ```
 
 2. 백엔드(FastAPI)

--- a/README.md
+++ b/README.md
@@ -57,9 +57,15 @@ npm install
 
 ## 📦 실행 방법
 1. 백엔드 실행
+- 로컬 환경 테스트
 ```
 cd backend
 uvicorn main:app --reload
+```
+- 모바일 앱 연동 테스트(외부 접속 허용 필요)
+```
+cd backend
+uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 2. 프론트엔드 실행

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -2,7 +2,17 @@ import sys, os, jose.jwt, pytest
 from sqlalchemy.orm import Session
 from unittest.mock import patch, MagicMock
 from database import get_db
+from fastapi.testclient import TestClient
+from main import app
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+client = TestClient(app)
+
+def test_root():
+    # 루트 경로("/")로 GET 요청
+    response = client.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Closet App API 실행 중", "docs": "/docs"}
 
 class TestSignup:
     def test_정상_가입(self, client):

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,5 +1,7 @@
-import sys, os, jose.jwt
+import sys, os, jose.jwt, pytest
 from sqlalchemy.orm import Session
+from unittest.mock import patch, MagicMock
+from database import get_db
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
 class TestSignup:
@@ -90,3 +92,26 @@ class TestStyleUpdate:
         
         assert res.status_code == 200
         assert res.json()["preferred_style"] == "캐주얼"
+
+def test_get_db():
+    # SessionLocal을 Mocking하여 실제 DB에 연결하지 않고 가짜 세션 생성
+    with patch("database.SessionLocal") as mock_session_local:
+        mock_db_session = MagicMock()
+        mock_session_local.return_value = mock_db_session
+
+        # 제너레이터 객체 생성
+        db_generator = get_db()
+
+        # try 블록 검증: next()를 호출하여 yield된 세션이 mock 객체인지 확인
+        db = next(db_generator)
+        assert db == mock_db_session
+        
+        # 아직 제너레이터가 끝나지 않았으므로 close()는 호출되지 않아야 함
+        mock_db_session.close.assert_not_called()
+
+        # finally 블록 검증: 한 번 더 next()를 호출하여 제너레이터를 종료시킴
+        with pytest.raises(StopIteration):
+            next(db_generator)
+
+        # 제너레이터가 종료되면서 finally 블록의 db.close()가 호출되었는지 확인
+        mock_db_session.close.assert_called_once()

--- a/backend/tests/test_clothes.py
+++ b/backend/tests/test_clothes.py
@@ -1,4 +1,5 @@
-import sys, os, io
+import sys, os, io, pytest
+from models import Clothes
 from unittest.mock import patch, mock_open
 from routers.clothes import get_material_tip, MATERIAL_TIPS
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
@@ -142,3 +143,20 @@ class TestClothes:
         res = client.get("/clothes", headers=auth_headers)
         assert res.status_code == 200
         assert res.json() == []
+
+class TestCostPerWear:
+    # 가성비 계산(cost_per_wear) 처리
+    def test_cost_per_wear_price_is_none(self):
+        # price가 None인 경우
+        clothes = Clothes(price=None, wear_count=5)
+        assert clothes.cost_per_wear is None
+
+    def test_cost_per_wear_count_is_zero(self):
+        # wear_count가 0인 경우
+        clothes = Clothes(price=50000, wear_count=0)
+        assert clothes.cost_per_wear is None
+
+    def test_cost_per_wear_normal_calculation(self):
+        # 정상적으로 계산되는 경우
+        clothes = Clothes(price=50000, wear_count=3)
+        assert clothes.cost_per_wear == 16667.0

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -1,0 +1,125 @@
+import pytest
+from datetime import date
+from pydantic import ValidationError
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from schemas import (
+    ClothesCreate, ClothesUpdate, ClothesResponse, FeedbackCreate, map_korean_to_enum_logic
+)
+from schemas import WearHistoryCreate
+from models import CategoryEnum, MaterialEnum, FeedbackTempEnum, FeedbackTpoEnum, StyleEnum
+
+class DummyInfo:
+    def __init__(self, field_name):
+        self.field_name = field_name
+
+class TestSchemas:
+    def test_map_korean_to_enum_logic_branches(self):
+        empty_style_clothes = ClothesCreate(
+            name="빈 스타일 옷", category="상의", style="   "
+        )
+        assert empty_style_clothes.style is None
+
+        material_clothes = ClothesCreate(
+            name="면 티셔츠", category="상의", material="면 100%"
+        )
+        assert material_clothes.material is not None 
+
+        enum_clothes = ClothesCreate(
+            name="기본 티셔츠", category=CategoryEnum("상의")
+        )
+        assert isinstance(enum_clothes.category, CategoryEnum)
+
+        with pytest.raises(ValidationError):
+            ClothesCreate(name="오류 티셔츠", category="알수없는카테고리")
+    
+    def test_map_korean_to_enum_logic_material_match(self):
+        mock_info = MagicMock()
+        mock_info.field_name = 'material'
+
+        result = map_korean_to_enum_logic("니트 100%", mock_info)
+        
+        assert result == "니트"
+
+    def test_material_no_match(self):
+        info = DummyInfo(field_name="material")
+        
+        result = map_korean_to_enum_logic("우주소재", info)
+        assert result == "우주소재"
+
+    def test_not_string_value(self):
+        info = DummyInfo(field_name="style")
+        
+        result_enum = map_korean_to_enum_logic(StyleEnum.casual, info)
+        assert result_enum == StyleEnum.casual
+        
+        result_int = map_korean_to_enum_logic(123, info)
+        assert result_int == 123
+
+    def test_clothes_update_validator(self):
+        update_data = ClothesUpdate(
+            name="수정된 바지", category="하의", color="블랙"
+        )
+        assert update_data.name == "수정된 바지"
+
+    def test_clothes_response_wrap_tags_sqlalchemy_obj(self):
+        mock_db_obj = MagicMock()
+        
+        mock_table = MagicMock()
+        col_names = ['clothes_id', 'name', 'price', 'wear_count', 'created_at', 'category']
+        mock_columns = []
+        for name in col_names:
+            col = MagicMock()
+            col.name = name
+            mock_columns.append(col)
+    
+        mock_table.columns = mock_columns
+    
+        mock_db_obj.__table__ = mock_table
+    
+        mock_db_obj.clothes_id = 1
+        mock_db_obj.name = "Mock 티셔츠"
+        mock_db_obj.price = 30000
+        mock_db_obj.wear_count = 5
+        mock_db_obj.created_at = datetime.now()
+        mock_db_obj.category = "상의"
+
+        response = ClothesResponse.model_validate(mock_db_obj)
+        assert response.id == 1
+
+    def test_clothes_response_cpw_zero_wear(self):
+        response = ClothesResponse(
+            clothes_id=2,
+            name="한번도 안입은 옷",
+            price=50000,
+            wear_count=0,
+            created_at=datetime.now(),
+            tags={"category": "아우터"}
+        )
+        assert response.cost_per_wear is None
+
+    def test_feedback_create_validator(self):
+        test_data = {
+        "clothes_id": 1,
+        "worn_date": date(2026, 5, 20),
+        "style": "캐주얼",
+        "feedback_temperature": "적당함"
+    }
+
+        obj = WearHistoryCreate(**test_data)
+
+        assert obj.clothes_id == 1
+        assert obj.worn_date == date(2026, 5, 20)
+
+    def test_feedback_create_with_none(self):
+        data = {
+            "history_id": 2,
+            "feedback_temperature": "",
+            "feedback_tpo": None
+        }
+        
+        feedback = FeedbackCreate(**data)
+        
+        assert feedback.feedback_temperature is None
+        assert feedback.feedback_tpo is None

--- a/backend/tests/test_utils.py
+++ b/backend/tests/test_utils.py
@@ -113,7 +113,7 @@ class TestGetBaseTime:
 
 
 class TestGetWeatherData:
-    """4. 기상청 단기예보 통신 및 날씨 분기 테스트 (전면 동기 구조로 변경)"""
+    """4. 기상청 단기예보 통신 및 날씨 분기 테스트 (동기 함수)"""
 
     @patch('utils.requests.get')
     def test_invalid_address(self, mock_requests_get):
@@ -212,4 +212,35 @@ class TestGetWeatherData:
         mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
         
         res = get_weather_data("서울")
+        assert res == {"temperature": 20.0, "condition": "sunny"}
+
+    @patch('utils.requests.get')
+    def test_weather_api_exception_second_call(self, mock_requests_get):
+        # 주소 변환은 정상 데이터 반환
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        # 날씨 API에서 Exception 발생하도록 지정
+        mock_requests_get.side_effect = [mock_geo_resp, Exception("Weather API Timeout")]
+        
+        res = get_weather_data("서울")
+        
+        # 예외가 발생해도 시스템이 멈추지 않고 기본값을 반환하는지 검증
+        assert res == {"temperature": 20.0, "condition": "sunny"}
+
+    @patch('utils.requests.get')
+    def test_weather_data_parsing_keyerror(self, mock_requests_get):
+        # 주소 변환 정상
+        mock_geo_resp = MagicMock()
+        mock_geo_resp.json.return_value = [{'lat': '37.5', 'lon': '126.9'}]
+        
+        # 날씨 API 호출은 성공했으나, 정상 구조(response -> body -> items)가 없는 데이터 반환
+        mock_weather_resp = MagicMock()
+        mock_weather_resp.json.return_value = {"unexpected_data_structure": "error"}
+        
+        mock_requests_get.side_effect = [mock_geo_resp, mock_weather_resp]
+        
+        res = get_weather_data("서울")
+        
+        # JSON 키 에러가 발생하면 except Exception: 블록으로 빠져나와 기본값을 반환하는지 검증
         assert res == {"temperature": 20.0, "condition": "sunny"}


### PR DESCRIPTION
유닛테스트 파일에 대한 수정입니다.

test_auth.py : yield db와 close db 호출 검증 테스트 추가, 루트 경로로 GET 요청 테스트 추가
test_clothes.py : 가성비 계산 로직 테스트 추가 (cost_per_wear 처리, wear_count가 0인 경우 처리, 정상적으로 가성비 계산이 되었을 경우 처리)
test_utils.py : 날씨 파싱과정에서 오류 발생 테스트 추가 (주소는 정상적으로 변환 되었는데, 날씨 API에서 오류가 발생하는 경우 처리)
test_schemas.py : 데이터 한글 매핑 테스트 추가 (이름, 카테고리, 소재가 정상적으로 한글 매핑이 되는지 확인), 옷 업데이트 검증 로직 테스트 추가 (옷의 이름을 업데이트하는 경우 처리), 옷 데이터 응답 로직 테스트 추가, 옷 피드백 생성 로직 테스트 추가

결과 : UnitTest Coverage 94% 달성